### PR TITLE
fixed a bug with links starting with "/"

### DIFF
--- a/encfs/DirNode.cpp
+++ b/encfs/DirNode.cpp
@@ -360,6 +360,18 @@ DirNode::plainPath( const char *cipherPath_ )
 {
     try
     {
+	// bjw 2012/12/2
+	//
+	// In --reverse mode, absolute "plain" paths need special "+" format encoding just like
+	//    relativeCipherPath's do in forward mode.
+	//
+	if (fsConfig->reverseEncryption)
+	{
+	    if ( cipherPath_[0] == '/' )
+		return string("+") + naming->decodeName( cipherPath_+1, 
+			strlen(cipherPath_+1) );
+	}
+	// end bjw mod
 	if( !strncmp( cipherPath_, rootDir.c_str(), 
 		    rootDir.length() ) )
 	{


### PR DESCRIPTION
This patch was in a bugreport in the old enfcs project on the Google Code project but didn't make it through shift to github.
Got the patch now from https://build.opensuse.org/request/show/245515
