### PR TITLE
Improve configure generation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,13 +60,14 @@ AX_CXX_COMPILE_STDCXX_11
 dnl Look for fuse headers.
 AX_EXT_HAVE_HEADER(fuse.h, /usr/include/fuse /usr/local/include/fuse \
                    /opt/include/fuse /opt/local/include/fuse \
-                   /usr/include/osxfuse /usr/local/include/osxfuse)
+                   /usr/include/osxfuse /usr/local/include/osxfuse \
+                   /opt/local/include/osxfuse)
 
 dnl Ensure the necessary paths are added to LDPATH
 AX_EXT_HAVE_LIB(/usr/lib /usr/local/lib /opt/lib /opt/local/lib, fuse,
-                fuse_new, [])
+                fuse_mount, [])
 AX_EXT_HAVE_LIB(/usr/lib /usr/local/lib /opt/lib /opt/local/lib, osxfuse,
-                fuse_new, [])
+                fuse_mount, [])
 
 if test "$GXX" = "yes"; then
     CXXFLAGS="-W -Wall -Wpointer-arith -Wwrite-strings $CXXFLAGS"


### PR DESCRIPTION
Hello!

I think their is a failure in configure.ac.

 Here is the commit message:

*change the way the configure check presence of library FUSE : previous
one search twice (one for adding the path of the library to LDFLAGS and
the other for eventually checking that the library is actually added)
for the same symbol (fuse_new) that resuls in the configure script
caching the first result of the test (which is 'false' because the
library where not still added) and reuseing it in the second test. A
solution is to use two different symbols for theses two tests).