### PR TITLE
Release 1.8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([encfs], [1.7.5])
+AC_INIT([encfs], [1.8])
 AC_CONFIG_SRCDIR([encfs/encfs.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
It has been three months since 1.8-rc1, no regressions were reported. I think it's time to relase 1.8.
Once you pull this I will create the tag.