### PR TITLE
Work around #14 (Editing Configuration File Disables MACs) with "--require-macs"

### DIFF
--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -855,14 +855,26 @@ static bool boolDefaultYes(const char *prompt) {
 /**
  * Ask the user whether to enable block MAC and random header bytes
  */
-static void selectBlockMAC(int *macBytes, int *macRandBytes) {
-  // xgroup(setup)
-  bool addMAC = boolDefaultNo(
-      _("Enable block authentication code headers\n"
-        "on every block in a file?  This adds about 12 bytes per block\n"
-        "to the storage requirements for a file, and significantly affects\n"
-        "performance but it also means [almost] any modifications or errors\n"
-        "within a block will be caught and will cause a read error."));
+static void selectBlockMAC(int *macBytes, int *macRandBytes, bool forceMac) {
+  bool addMAC = false;
+  if (!forceMac) {
+    // xgroup(setup)
+    addMAC = boolDefaultNo(
+        _("Enable block authentication code headers\n"
+          "on every block in a file?  This adds about 12 bytes per block\n"
+          "to the storage requirements for a file, and significantly affects\n"
+          "performance but it also means [almost] any modifications or errors\n"
+          "within a block will be caught and will cause a read error."));
+  } else {
+    cout <<_("Enable block authentication code headers\n"
+      "on every block in a file?  This adds about 12 bytes per block\n"
+      "to the storage requirements for a file, and significantly affects\n"
+      "performance but it also means [almost] any modifications or errors\n"
+      "within a block will be caught and will cause a read error.");
+    cout << _("You specified --require-mac.  "
+              "Forcing block authentication code headers...\n");
+    addMAC = true;
+  }
 
   if (addMAC)
     *macBytes = 8;
@@ -1026,6 +1038,10 @@ RootPtr createV6Config(EncFS_Context *ctx, const shared_ptr<EncFS_Opts> &opts) {
     nameIOIface = BlockNameIO::CurrentInterface();
     uniqueIV = true;
 
+    if (opts->requireMac) {
+      blockMACBytes = 8;
+    }
+
     if (reverseEncryption) {
       cout << _("reverse encryption - chained IV disabled") << "\n";
     } else {
@@ -1070,7 +1086,7 @@ RootPtr createV6Config(EncFS_Context *ctx, const shared_ptr<EncFS_Opts> &opts) {
              << "\n";
         externalIV = false;
       }
-      selectBlockMAC(&blockMACBytes, &blockMACRandBytes);
+      selectBlockMAC(&blockMACBytes, &blockMACRandBytes, opts->requireMac);
       allowHoles = selectZeroBlockPassThrough();
     }
   }
@@ -1500,6 +1516,12 @@ RootPtr initFS(EncFS_Context *ctx, const shared_ptr<EncFS_Opts> &opts) {
   shared_ptr<EncFSConfig> config(new EncFSConfig);
 
   if (readConfig(opts->rootDir, config) != Config_None) {
+    if (config->blockMACBytes == 0 && opts->requireMac) {
+      cout
+         << _("The configuration disabled MAC, but you passed --require-mac\n");
+      return rootInfo;
+    }
+
     if (opts->reverseEncryption) {
       if (config->blockMACBytes != 0 || config->blockMACRandBytes != 0 ||
           config->externalIVChaining ||

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -866,13 +866,8 @@ static void selectBlockMAC(int *macBytes, int *macRandBytes, bool forceMac) {
           "performance but it also means [almost] any modifications or errors\n"
           "within a block will be caught and will cause a read error."));
   } else {
-    cout <<_("Enable block authentication code headers\n"
-      "on every block in a file?  This adds about 12 bytes per block\n"
-      "to the storage requirements for a file, and significantly affects\n"
-      "performance but it also means [almost] any modifications or errors\n"
-      "within a block will be caught and will cause a read error.");
-    cout << _("You specified --require-mac.  "
-              "Forcing block authentication code headers...\n");
+    cout << _("\n\nYou specified --require-macs.  "
+              "Enabling block authentication code headers...\n\n");
     addMAC = true;
   }
 
@@ -1518,7 +1513,7 @@ RootPtr initFS(EncFS_Context *ctx, const shared_ptr<EncFS_Opts> &opts) {
   if (readConfig(opts->rootDir, config) != Config_None) {
     if (config->blockMACBytes == 0 && opts->requireMac) {
       cout
-         << _("The configuration disabled MAC, but you passed --require-mac\n");
+         << _("The configuration disabled MAC, but you passed --require-macs\n");
       return rootInfo;
     }
 

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -88,6 +88,8 @@ struct EncFS_Opts {
 
   bool readOnly; // Mount read-only
 
+  bool requireMac; // Throw an error if MAC is disabled
+
   ConfigMode configMode;
 
   EncFS_Opts() {
@@ -104,6 +106,7 @@ struct EncFS_Opts {
     configMode = Config_Prompt;
     noCache = false;
     readOnly = false;
+    requireMac = false;
   }
 };
 

--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -121,6 +121,15 @@ password.  If this succeeds, then the filesystem becomes available again.
 Do not mount the filesystem when encfs starts; instead, delay mounting until
 first use. This option only makes sense with B<--ondemand>.
 
+=item B<--require-macs>
+
+If creating a new filesystem, this forces block authentication code headers to
+be enabled.  When mounting an existing filesystem, this causes encfs to exit
+if block authentication code headers are not enabled.
+
+This can be used to improve security in case the ciphertext is vulnerable to
+tampering, by preventing an attacker from disabling MACs in the config file.
+
 =item B<--reverse>
 
 Normally B<EncFS> provides a plaintext view of data on demand.  Normally it

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -190,6 +190,7 @@ static bool processArgs(int argc, char *argv[],
   out->opts->useStdin = false;
   out->opts->annotate = false;
   out->opts->reverseEncryption = false;
+  out->opts->requireMac = false;
 
   bool useDefaultFlags = true;
 
@@ -224,6 +225,7 @@ static bool processArgs(int argc, char *argv[],
       {"reverse", 0, 0, 'r'},    // reverse encryption
       {"standard", 0, 0, '1'},   // standard configuration
       {"paranoia", 0, 0, '2'},   // standard configuration
+      {"require-mac", 0, 0, 515}, // require MACs (to address Github #14)
       {0, 0, 0, 0}};
 
   while (1) {
@@ -257,6 +259,9 @@ static bool processArgs(int argc, char *argv[],
         break;
       case 513:
         out->opts->annotate = true;
+        break;
+      case 515:
+        out->opts->requireMac = true;
         break;
       case 'f':
         out->isDaemon = false;

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -57,6 +57,8 @@
 extern "C" void fuse_unmount_compat22(const char *mountpoint);
 #define fuse_unmount fuse_unmount_compat22
 
+#define LONG_OPT_REQUIRE_MAC 515
+
 using namespace std;
 using namespace rlog;
 using namespace rel;
@@ -225,7 +227,7 @@ static bool processArgs(int argc, char *argv[],
       {"reverse", 0, 0, 'r'},    // reverse encryption
       {"standard", 0, 0, '1'},   // standard configuration
       {"paranoia", 0, 0, '2'},   // standard configuration
-      {"require-mac", 0, 0, 515}, // require MACs (to address Github #14)
+      {"require-macs", 0, 0, LONG_OPT_REQUIRE_MAC}, // require MACs
       {0, 0, 0, 0}};
 
   while (1) {
@@ -260,7 +262,7 @@ static bool processArgs(int argc, char *argv[],
       case 513:
         out->opts->annotate = true;
         break;
-      case 515:
+      case LONG_OPT_REQUIRE_MAC:
         out->opts->requireMac = true;
         break;
       case 'f':


### PR DESCRIPTION
This patch implements the workaround proposed by
https://defuse.ca/audits/encfs.htm to create a --require-macs command
line argument. If this argument is passed, encfs will refuse to mount
with MACs disabled. When creating a filesystem, encfs will force MACs to
be enabled.

This affects issue #14.