### PR TITLE
Add shared_ptr.h to tarball generated by make dist

### DIFF
--- a/encfs/Makefile.am
+++ b/encfs/Makefile.am
@@ -122,6 +122,7 @@ noinst_HEADERS = \
     Range.h \
     RawFileIO.h \
     readpassphrase.h \
+    shared_ptr.h \
     SSL_Cipher.h \
     StreamNameIO.h
 


### PR DESCRIPTION
Makes the tarball generated by make dist compile fine for me.