### PR TITLE
Build fixes to compile on Linux Mint 17.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 2.8)
 project(EncFS C CXX)
 
 set (ENCFS_MAJOR 1)
@@ -12,6 +12,10 @@ set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
   "${CMAKE_SOURCE_DIR}/cmake")
 
 # We need C++ 11
+if(CMAKE_COMPILER_IS_GNUCXX)
+  list(APPEND CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+endif()
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 


### PR DESCRIPTION
Unfortunately encfs 1.7.4 shipping with Linux Mint 17.2 appears broken (Unable to find nameio interface nameio/block, version 4:0:0).

This pull request puts in two minor tweaks to the CMakeLists.txt to build with the versions of CMake (2.8.12.2) and g++ (4.8.4) that Mint ships with.