### PR TITLE
Perform checks to ensure that we're not descending into ourself.

### DIFF
--- a/encfs/DirNode.h
+++ b/encfs/DirNode.h
@@ -86,6 +86,9 @@ class DirNode {
   // return the path to the root directory
   std::string rootDirectory();
 
+  // recursive lookup check
+  bool touchesMountpoint(const char *realPath) const;
+
   // find files
   shared_ptr<FileNode> lookupNode(const char *plaintextName,
                                   const char *requestor);

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -69,6 +69,7 @@ enum ConfigMode { Config_Prompt, Config_Standard, Config_Paranoia };
  */
 struct EncFS_Opts {
   std::string rootDir;
+  std::string mountPoint; // where to make filesystem visible
   bool createIfNotFound;  // create filesystem if not found
   bool idleTracking;      // turn on idle monitoring of filesystem
   bool mountOnDemand;     // mounting on-demand

--- a/encfs/encfs.cpp
+++ b/encfs/encfs.cpp
@@ -139,6 +139,14 @@ static int withFileNode(const char *opName, const char *path,
 
     rAssert(fnode.get() != NULL);
     rLog(Info, "%s %s", opName, fnode->cipherName());
+
+    // check that we're not recursing into the mount point itself
+    if (FSRoot->touchesMountpoint(fnode->cipherName())) {
+      rInfo("%s error: Tried to touch mountpoint: '%s'",
+            opName, fnode->cipherName());
+      return res; // still -EIO
+    }
+
     res = op(fnode.get());
 
     if (res < 0) rInfo("%s error: %s", opName, strerror(-res));


### PR DESCRIPTION
It's possible to mount this filesystem in a descendant of the real
(source) filesystem. For instance, one could do this:

    encfs --reverse / /home/encrypted/rootfs

At that point, all files in `/` (like `/root/.bashrc`) are also in
`/home/encrypted/rootfs` (like `/home/encrypted/rootfs/root/.bashrc`).

This can be useful when you want to export an encrypted copy of the
filesystem: the remote backup machine can fetch any file, but all files
will be encrypted.

However, the mountpoint itself is also there:

    /home/encrypted/rootfs/home/encrypted/rootfs

This would cause a `find /` of the filesystem to take infinite time. And
what's worse; trying to read files from there would cause the filesystem
to lock up:

    cat /home/encrypted/rootfs/home/encrypted/rootfs/root/.bashrc
    (infinite hang)

This patch adds an extra check so the filesystem refuses to descend into
itself.