### PR TITLE
OS X Compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,6 @@ endif (HAVE_GNU11_FLAG)
 find_package (FUSE REQUIRED)
 include_directories (${FUSE_INCLUDE_DIR})
 add_definitions (-D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26)
-if (APPLE)
-    add_definitions (-D__FreeBSD__=10)
-    # XXX: Fall back to stdc++, due to clang 5.0.1 header file issues
-    # (missing sys/endian.h, needed by standard c++ header files).
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.7")
-endif (APPLE)
 
 # Packaging config.
 set (CPACK_PACKAGE_NAME "Encfs")

--- a/CMakeModules/FindTinyXML.cmake
+++ b/CMakeModules/FindTinyXML.cmake
@@ -11,12 +11,12 @@ IF( TINYXML_INCLUDE_DIR )
     SET( TinyXML_FIND_QUIETLY TRUE )
 ENDIF( TINYXML_INCLUDE_DIR )
 
-FIND_PATH( TINYXML_INCLUDE_DIR "tinyxml.h"
-           PATH_SUFFIXES "tinyxml" )
+FIND_PATH( TINYXML_INCLUDE_DIR "tinyxml2.h"
+           PATH_SUFFIXES "tinyxml2" )
 
 FIND_LIBRARY( TINYXML_LIBRARIES
-              NAMES "tinyxml"
-              PATH_SUFFIXES "tinyxml" )
+              NAMES "tinyxml2"
+              PATH_SUFFIXES "tinyxml2" )
 
 # handle the QUIETLY and REQUIRED arguments and set TINYXML_FOUND to TRUE if
 # all listed variables are TRUE

--- a/base/XmlReader.cpp
+++ b/base/XmlReader.cpp
@@ -29,7 +29,7 @@
 #include <cstring>
 #include <map>
 
-#include <tinyxml.h>
+#include <tinyxml2.h>
 
 #include <glog/logging.h>
 #include "base/base64.h"
@@ -124,13 +124,13 @@ bool XmlValue::read(const char *path, Interface *out) const {
   return true;
 }
 
-std::string safeValueForNode(const TiXmlElement *element) {
+std::string safeValueForNode(const tinyxml2::XMLElement *element) {
   std::string value;
   if (element == NULL) return value;
 
-  const TiXmlNode *child = element->FirstChild();
+  const tinyxml2::XMLNode *child = element->FirstChild();
   if (child) {
-    const TiXmlText *childText = child->ToText();
+    const tinyxml2::XMLText *childText = child->ToText();
     if (childText) value = childText->Value();
   }
 
@@ -138,10 +138,10 @@ std::string safeValueForNode(const TiXmlElement *element) {
 }
 
 class XmlNode : virtual public XmlValue {
-  const TiXmlElement *element;
+  const tinyxml2::XMLElement *element;
 
  public:
-  XmlNode(const TiXmlElement *element_)
+  XmlNode(const tinyxml2::XMLElement *element_)
       : XmlValue(safeValueForNode(element_)), element(element_) {}
 
   virtual ~XmlNode() {}
@@ -154,7 +154,7 @@ class XmlNode : virtual public XmlValue {
       else
         return XmlValuePtr();
     } else {
-      const TiXmlElement *el = element->FirstChildElement(name);
+      const tinyxml2::XMLElement *el = element->FirstChildElement(name);
       if (el)
         return XmlValuePtr(new XmlNode(el));
       else
@@ -164,7 +164,7 @@ class XmlNode : virtual public XmlValue {
 };
 
 struct XmlReader::XmlReaderData {
-  shared_ptr<TiXmlDocument> doc;
+  shared_ptr<tinyxml2::XMLDocument> doc;
 };
 
 XmlReader::XmlReader() : pd(new XmlReaderData()) {}
@@ -172,22 +172,22 @@ XmlReader::XmlReader() : pd(new XmlReaderData()) {}
 XmlReader::~XmlReader() {}
 
 bool XmlReader::load(const char *fileName) {
-  pd->doc.reset(new TiXmlDocument(fileName));
+  pd->doc.reset(new tinyxml2::XMLDocument());
 
-  return pd->doc->LoadFile();
+  return pd->doc->LoadFile(fileName);
 }
 
 XmlValuePtr XmlReader::operator[](const char *name) const {
-  TiXmlNode *node = pd->doc->FirstChild(name);
+  tinyxml2::XMLNode *node = pd->doc->FirstChildElement(name);
   if (node == NULL) {
     LOG(ERROR) << "Xml node " << name << " not found";
     return XmlValuePtr(new XmlValue());
   }
 
-  TiXmlElement *element = node->ToElement();
+  tinyxml2::XMLElement *element = node->ToElement();
   if (element == NULL) {
     LOG(ERROR) << "Xml node " << name
-               << " not element, type = " << node->Type();
+               << " not element";
     return XmlValuePtr(new XmlValue());
   }
 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -558,7 +558,7 @@ int main(int argc, char *argv[]) {
   encfs_oper.utimens = encfs_utimens;
 // encfs_oper.bmap = encfs_bmap;
 
-#if (__FreeBSD__ >= 10)
+#if (__FreeBSD__ >= 10) || defined(__APPLE__)
 // encfs_oper.setvolname
 // encfs_oper.exchange
 // encfs_oper.getxtimes

--- a/fs/Context.cpp
+++ b/fs/Context.cpp
@@ -72,7 +72,7 @@ void EncFS_Context::setRoot(const shared_ptr<DirNode> &r) {
   if (r) rootCipherDir = r->rootDirectory();
 }
 
-bool EncFS_Context::isMounted() const { return root; }
+bool EncFS_Context::isMounted() const { return root != NULL; }
 
 int EncFS_Context::getAndResetUsageCounter() {
   Lock lock(contextMutex);

--- a/fs/DirNode.cpp
+++ b/fs/DirNode.cpp
@@ -157,7 +157,7 @@ class RenameOp {
 
   ~RenameOp();
 
-  operator bool() const { return renameList; }
+  operator bool() const { return renameList != NULL; }
 
   bool apply();
   void undo();

--- a/fs/DirNode.cpp
+++ b/fs/DirNode.cpp
@@ -80,7 +80,7 @@ static bool _nextName(struct dirent *&de, const shared_ptr<DIR> &dir,
 
   if (de) {
     if (fileType) {
-#if defined(_DIRENT_HAVE_D_TYPE) || defined(__FreeBSD__)
+#if defined(_DIRENT_HAVE_D_TYPE) || defined(__FreeBSD__) || defined(__APPLE__)
       *fileType = de->d_type;
 #else
 #warning "struct dirent.d_type not supported"

--- a/fs/RawFileIO.cpp
+++ b/fs/RawFileIO.cpp
@@ -245,7 +245,7 @@ int RawFileIO::truncate(off_t size) {
 
   if (fd >= 0 && canWrite) {
     res = ::ftruncate(fd, size);
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
     ::fdatasync(fd);
 #endif
   } else

--- a/util/encfsctl.pod
+++ b/util/encfsctl.pod
@@ -1,3 +1,5 @@
+=pod
+
 =cut
 Copyright (c) 2003-2004, Valient Gough <vgough@pobox.com>
 All rights reserved.
@@ -6,8 +8,6 @@ EncFS is free software; you can distribute it and/or modify it under the terms
 of the GNU General Public License (GPL), as published by the Free Software
 Foundation; either version 2 of the License, or (at your option) any later
 version.
-
-=pod
 
 =head1 NAME
 


### PR DESCRIPTION
- Fix compilation on OS X.
- Switch to TinyXML-2, which is more modern, and more easy to compile & install as a lib.
