### PR TITLE
Bugfix: Labels are backwards for "Block" and "Block32" encoding

### DIFF
--- a/encfs/BlockNameIO.cpp
+++ b/encfs/BlockNameIO.cpp
@@ -130,7 +130,7 @@ int BlockNameIO::maxEncodedNameLen(int plaintextNameLen) const {
 
 int BlockNameIO::maxDecodedNameLen(int encodedNameLen) const {
   int decLen256 = _caseInsensitive ? B32ToB256Bytes(encodedNameLen)
-                                 : B64ToB256Bytes(encodedNameLen);
+                                   : B64ToB256Bytes(encodedNameLen);
   return decLen256 - 2;  // 2 checksum bytes removed..
 }
 
@@ -184,7 +184,7 @@ int BlockNameIO::encodeName(const char *plaintextName, int length, uint64_t *iv,
 int BlockNameIO::decodeName(const char *encodedName, int length, uint64_t *iv,
                             char *plaintextName) const {
   int decLen256 =
-	  _caseInsensitive ? B32ToB256Bytes(length) : B64ToB256Bytes(length);
+      _caseInsensitive ? B32ToB256Bytes(length) : B64ToB256Bytes(length);
   int decodedStreamLen = decLen256 - 2;
 
   // don't bother trying to decode files which are too small

--- a/encfs/BlockNameIO.cpp
+++ b/encfs/BlockNameIO.cpp
@@ -71,7 +71,7 @@ static bool BlockIO32_registered = NameIO::Register(
     // description of block name encoding algorithm..
     // xgroup(setup)
     gettext_noop(
-        "Block encoding with base32 output for case-sensitive systems"),
+        "Block encoding with base32 output for case-insensitive systems"),
     BlockNameIO::CurrentInterface(true), NewBlockNameIO32);
 
 /*
@@ -91,9 +91,9 @@ static bool BlockIO32_registered = NameIO::Register(
     - Version 4.0 adds support for base32, creating names more suitable for
       case-insensitive filesystems (eg Mac).
 */
-Interface BlockNameIO::CurrentInterface(bool caseSensitive) {
+Interface BlockNameIO::CurrentInterface(bool caseInsensitive) {
   // implement major version 4 plus support for two prior versions
-  if (caseSensitive)
+  if (caseInsensitive)
     return Interface("nameio/block32", 4, 0, 2);
   else
     return Interface("nameio/block", 4, 0, 2);
@@ -101,12 +101,12 @@ Interface BlockNameIO::CurrentInterface(bool caseSensitive) {
 
 BlockNameIO::BlockNameIO(const rel::Interface &iface,
                          const shared_ptr<Cipher> &cipher, const CipherKey &key,
-                         int blockSize, bool caseSensitiveEncoding)
+                         int blockSize, bool caseInsensitiveEncoding)
     : _interface(iface.current()),
       _bs(blockSize),
       _cipher(cipher),
       _key(key),
-      _caseSensitive(caseSensitiveEncoding) {
+      _caseInsensitive(caseInsensitiveEncoding) {
   // just to be safe..
   rAssert(blockSize < 128);
 }
@@ -114,7 +114,7 @@ BlockNameIO::BlockNameIO(const rel::Interface &iface,
 BlockNameIO::~BlockNameIO() {}
 
 Interface BlockNameIO::interface() const {
-  return CurrentInterface(_caseSensitive);
+  return CurrentInterface(_caseInsensitive);
 }
 
 int BlockNameIO::maxEncodedNameLen(int plaintextNameLen) const {
@@ -122,14 +122,14 @@ int BlockNameIO::maxEncodedNameLen(int plaintextNameLen) const {
   // the size of too much space rather then too little.
   int numBlocks = (plaintextNameLen + _bs) / _bs;
   int encodedNameLen = numBlocks * _bs + 2;  // 2 checksum bytes
-  if (_caseSensitive)
+  if (_caseInsensitive)
     return B256ToB32Bytes(encodedNameLen);
   else
     return B256ToB64Bytes(encodedNameLen);
 }
 
 int BlockNameIO::maxDecodedNameLen(int encodedNameLen) const {
-  int decLen256 = _caseSensitive ? B32ToB256Bytes(encodedNameLen)
+  int decLen256 = _caseInsensitive ? B32ToB256Bytes(encodedNameLen)
                                  : B64ToB256Bytes(encodedNameLen);
   return decLen256 - 2;  // 2 checksum bytes removed..
 }
@@ -164,7 +164,7 @@ int BlockNameIO::encodeName(const char *plaintextName, int length, uint64_t *iv,
   int encodedStreamLen = length + 2 + padding;
   int encLen;
 
-  if (_caseSensitive) {
+  if (_caseInsensitive) {
     encLen = B256ToB32Bytes(encodedStreamLen);
 
     changeBase2Inline((unsigned char *)encodedName, encodedStreamLen, 8, 5,
@@ -184,7 +184,7 @@ int BlockNameIO::encodeName(const char *plaintextName, int length, uint64_t *iv,
 int BlockNameIO::decodeName(const char *encodedName, int length, uint64_t *iv,
                             char *plaintextName) const {
   int decLen256 =
-      _caseSensitive ? B32ToB256Bytes(length) : B64ToB256Bytes(length);
+	  _caseInsensitive ? B32ToB256Bytes(length) : B64ToB256Bytes(length);
   int decodedStreamLen = decLen256 - 2;
 
   // don't bother trying to decode files which are too small
@@ -196,7 +196,7 @@ int BlockNameIO::decodeName(const char *encodedName, int length, uint64_t *iv,
   BUFFER_INIT(tmpBuf, 32, (unsigned int)length);
 
   // decode into tmpBuf,
-  if (_caseSensitive) {
+  if (_caseInsensitive) {
     AsciiToB32((unsigned char *)tmpBuf, (unsigned char *)encodedName, length);
     changeBase2Inline((unsigned char *)tmpBuf, length, 5, 8, false);
   } else {

--- a/encfs/BlockNameIO.h
+++ b/encfs/BlockNameIO.h
@@ -42,7 +42,7 @@ class BlockNameIO : public NameIO {
 
   BlockNameIO(const rel::Interface &iface, const shared_ptr<Cipher> &cipher,
               const CipherKey &key, int blockSize,
-              bool caseSensitiveEncoding = false);
+              bool caseInsensitiveEncoding = false);
   virtual ~BlockNameIO();
 
   virtual rel::Interface interface() const;
@@ -64,7 +64,7 @@ class BlockNameIO : public NameIO {
   int _bs;
   shared_ptr<Cipher> _cipher;
   CipherKey _key;
-  bool _caseSensitive;
+  bool _caseInsensitive;
 };
 
 #endif

--- a/encfs/BlockNameIO.h
+++ b/encfs/BlockNameIO.h
@@ -38,7 +38,7 @@ class Cipher;
 */
 class BlockNameIO : public NameIO {
  public:
-  static rel::Interface CurrentInterface(bool caseSensitive = false);
+  static rel::Interface CurrentInterface(bool caseInsensitive = false);
 
   BlockNameIO(const rel::Interface &iface, const shared_ptr<Cipher> &cipher,
               const CipherKey &key, int blockSize,

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -1016,7 +1016,14 @@ RootPtr createV6Config(EncFS_Context *ctx, const shared_ptr<EncFS_Opts> &opts) {
     keySize = 256;
     blockSize = DefaultBlockSize;
     alg = findCipherAlgorithm("AES", keySize);
-    nameIOIface = BlockNameIO::CurrentInterface();
+
+	// If case-insensitive system, opt for Block32 filename encoding 
+#if defined(__APPLE__) || defined(WIN32)
+	nameIOIface = BlockNameIO::CurrentInterface(true);
+#else
+	nameIOIface = BlockNameIO::CurrentInterface();
+#endif
+
     blockMACBytes = 8;
     blockMACRandBytes = 0;  // using uniqueIV, so this isn't necessary
     externalIV = true;
@@ -1029,7 +1036,13 @@ RootPtr createV6Config(EncFS_Context *ctx, const shared_ptr<EncFS_Opts> &opts) {
     keySize = 192;
     blockSize = DefaultBlockSize;
     alg = findCipherAlgorithm("AES", keySize);
-    nameIOIface = BlockNameIO::CurrentInterface();
+
+	// If case-insensitive system, opt for Block32 filename encoding 
+#if defined(__APPLE__) || defined(WIN32)
+    nameIOIface = BlockNameIO::CurrentInterface(true);
+#else
+	nameIOIface = BlockNameIO::CurrentInterface();
+#endif
 
     if (opts->requireMac) {
       blockMACBytes = 8;

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -1017,11 +1017,11 @@ RootPtr createV6Config(EncFS_Context *ctx, const shared_ptr<EncFS_Opts> &opts) {
     blockSize = DefaultBlockSize;
     alg = findCipherAlgorithm("AES", keySize);
 
-	// If case-insensitive system, opt for Block32 filename encoding 
+    // If case-insensitive system, opt for Block32 filename encoding 
 #if defined(__APPLE__) || defined(WIN32)
-	nameIOIface = BlockNameIO::CurrentInterface(true);
+    nameIOIface = BlockNameIO::CurrentInterface(true);
 #else
-	nameIOIface = BlockNameIO::CurrentInterface();
+    nameIOIface = BlockNameIO::CurrentInterface();
 #endif
 
     blockMACBytes = 8;
@@ -1037,11 +1037,11 @@ RootPtr createV6Config(EncFS_Context *ctx, const shared_ptr<EncFS_Opts> &opts) {
     blockSize = DefaultBlockSize;
     alg = findCipherAlgorithm("AES", keySize);
 
-	// If case-insensitive system, opt for Block32 filename encoding 
+    // If case-insensitive system, opt for Block32 filename encoding 
 #if defined(__APPLE__) || defined(WIN32)
     nameIOIface = BlockNameIO::CurrentInterface(true);
 #else
-	nameIOIface = BlockNameIO::CurrentInterface();
+    nameIOIface = BlockNameIO::CurrentInterface();
 #endif
 
     if (opts->requireMac) {


### PR DESCRIPTION
Block32 should be used for case-insensitive systems (not Block)