### PR TITLE
vendor tinyxml2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ set (ENCFS_NAME "Encrypted Filesystem")
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
   "${CMAKE_SOURCE_DIR}/cmake")
 
+option (BUILD_SHARED_LIBS "build shared libraries" OFF)
+option (USE_INTERNAL_TINYXML "use build-in TinyXML2" ON)
+
 # We need C++ 11
 if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.0)
   # CMake 3.1 has built-in CXX standard checks.
@@ -48,8 +51,16 @@ add_definitions (-D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26)
 find_package (OpenSSL REQUIRED)
 include_directories (${OPENSSL_INCLUDE_DIR})
 
-find_package (TinyXML REQUIRED)
-include_directories (${TINYXML_INCLUDE_DIR})
+if (USE_INTERNAL_TINYXML)
+  message("-- Using local TinyXML2 copy")
+  add_subdirectory(tinyxml2-3.0.0)
+  include_directories(${CMAKE_SOURCE_DIR}/tinyxml2-3.0.0)
+  link_directories(${CMAKE_BINARY_DIR}/tinyxml2-3.0.0)
+  set(TINYXML_LIBRARIES tinyxml2)
+else ()
+  find_package (TinyXML REQUIRED)
+  include_directories (${TINYXML_INCLUDE_DIR})
+endif ()
 
 find_package (RLog REQUIRED)
 add_definitions (-DRLOG_COMPONENT="encfs")
@@ -129,9 +140,10 @@ set(SOURCE_FILES
   encfs/StreamNameIO.cpp
   encfs/XmlReader.cpp
 )
-add_library(encfs SHARED ${SOURCE_FILES})
-set_property(TARGET encfs PROPERTY VERSION ${ENCFS_VERSION})
-set_property(TARGET encfs PROPERTY SOVERSION ${ENCFS_SOVERSION})
+add_library(encfs ${SOURCE_FILES})
+set_target_properties(encfs PROPERTIES
+  VERSION ${ENCFS_VERSION}
+  SOVERSION ${ENCFS_SOVERSION})
 target_link_libraries(encfs
   ${FUSE_LIBRARIES}
   ${OPENSSL_LIBRARIES}

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   pre:
-    - sudo apt-get install cmake libfuse-dev librlog-dev libgettextpo-dev libtinyxml2-dev
+    - sudo apt-get install cmake libfuse-dev librlog-dev libgettextpo-dev
     - bash ./ci/install-gcc.sh
 
 test:

--- a/drone-config/Dockerfile
+++ b/drone-config/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu
 # Do system updates and install dependencies
 RUN apt-get update
 RUN apt-get -y upgrade
-RUN sudo apt-get -y install git wget autopoint libfuse-dev libtinyxml2-dev
+RUN sudo apt-get -y install git wget autopoint libfuse-dev
 RUN apt-get clean
 
 # Download Drone.io

--- a/drone-config/worker/Dockerfile
+++ b/drone-config/worker/Dockerfile
@@ -35,6 +35,5 @@ RUN     apt-get -y upgrade \
             librlog-dev \
             gettext \
             libgettextpo-dev \
-            libtinyxml2-dev \
         && apt-get clean
 

--- a/tinyxml2-3.0.0/.gitignore
+++ b/tinyxml2-3.0.0/.gitignore
@@ -1,0 +1,13 @@
+# intermediate files
+Win32/
+x64/
+ipch/
+resources/out/
+tinyxml2/tinyxml2-cbp/bin/
+tinyxml2/tinyxml2-cbp/obj/
+*.sdf
+*.suo
+*.opensdf
+*.user
+*.depend
+*.layout

--- a/tinyxml2-3.0.0/CMakeLists.txt
+++ b/tinyxml2-3.0.0/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+cmake_policy(VERSION 2.6)
+
+project(tinyxml2)
+include(GNUInstallDirs)
+#enable_testing()
+
+#CMAKE_BUILD_TOOL
+
+################################
+# set lib version here
+
+set(GENERIC_LIB_VERSION "3.0.0")
+set(GENERIC_LIB_SOVERSION "3")
+
+
+################################
+# Add common source 
+
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/.")
+
+################################
+# Add custom target to copy all data
+
+set(TARGET_DATA_COPY DATA_COPY)
+if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+	add_custom_target(
+		${TARGET_DATA_COPY}
+	 	COMMAND ${CMAKE_COMMAND} -E echo "In source build")
+else(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+	make_directory(${CMAKE_CURRENT_BINARY_DIR}/resources/)
+	add_custom_target(
+		${TARGET_DATA_COPY}
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/dream.xml ${CMAKE_CURRENT_BINARY_DIR}/resources/
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/empty.xml ${CMAKE_CURRENT_BINARY_DIR}/resources/
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/utf8test.xml ${CMAKE_CURRENT_BINARY_DIR}/resources/
+		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/utf8testverify.xml ${CMAKE_CURRENT_BINARY_DIR}/resources/)
+endif(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+
+################################
+# Add definitions
+
+if(MSVC)
+	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif(MSVC)
+
+################################
+# Add targets
+option(BUILD_SHARED_LIBS "build shared or static libraries" OFF)
+add_library(tinyxml2 tinyxml2.cpp tinyxml2.h)
+set_target_properties(tinyxml2 PROPERTIES
+        COMPILE_DEFINITIONS "TINYXML2_EXPORT"
+	VERSION "${GENERIC_LIB_VERSION}"
+	SOVERSION "${GENERIC_LIB_SOVERSION}")
+
+add_executable(xmltest xmltest.cpp)
+add_dependencies(xmltest tinyxml2)
+add_dependencies(xmltest ${TARGET_DATA_COPY})
+target_link_libraries(xmltest tinyxml2)
+
+
+install(TARGETS tinyxml2
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES tinyxml2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+foreach(p LIB INCLUDE)
+	set(var CMAKE_INSTALL_${p}DIR)
+	if(NOT IS_ABSOLUTE "${${var}}")
+		set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+	endif()
+endforeach()
+
+configure_file(tinyxml2.pc.in tinyxml2.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+#add_test(xmltest ${SAMPLE_NAME} COMMAND $<TARGET_FILE:${SAMPLE_NAME}>)

--- a/tinyxml2-3.0.0/Makefile
+++ b/tinyxml2-3.0.0/Makefile
@@ -1,0 +1,6 @@
+all: xmltest
+xmltest: xmltest.cpp tinyxml2.cpp tinyxml2.h
+test: clean xmltest
+	./xmltest
+clean:
+	rm -f *.o xmltest

--- a/tinyxml2-3.0.0/contrib/html5-printer.cpp
+++ b/tinyxml2-3.0.0/contrib/html5-printer.cpp
@@ -1,0 +1,108 @@
+//  g++ -Wall -O2 contrib/html5-printer.cpp -o html5-printer -ltinyxml2
+
+//  This program demonstrates how to use "tinyxml2" to generate conformant HTML5
+//  by deriving from the "tinyxml2::XMLPrinter" class.
+
+//  http://dev.w3.org/html5/markup/syntax.html
+
+//  In HTML5, there are 16 so-called "void" elements.  "void elements" NEVER have
+//  inner content (but they MAY have attributes), and are assumed to be self-closing.
+//  An example of a self-closig HTML5 element is "<br/>" (line break)
+//  All other elements are called "non-void" and MUST never self-close.
+//  Examples: "<div class='lolcats'></div>".
+
+//  tinyxml2::XMLPrinter will emit _ALL_ XML elements with no inner content as
+//  self-closing.  This behavior produces space-effeceint XML, but incorrect HTML5.
+
+//  Author: Dennis Jenkins,  dennis (dot) jenkins (dot) 75 (at) gmail (dot) com.
+//  License: Same as tinyxml2 (zlib, see below)
+//  This example is a small contribution to the world!  Enjoy it!
+
+/*
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+not claim that you wrote the original software. If you use this
+software in a product, an acknowledgment in the product documentation
+would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and
+must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+distribution.
+*/
+
+
+#include <tinyxml2.h>
+#include <iostream>
+
+#if defined (_MSC_VER)
+#define strcasecmp stricmp
+#endif
+
+using namespace tinyxml2;
+
+// Contrived input containing a mix of void and non-void HTML5 elements.
+// When printed via XMLPrinter, some non-void elements will self-close (not valid HTML5).
+static const char input[] =
+"<html><body><p style='a'></p><br/>&copy;<col a='1' b='2'/><div a='1'></div></body></html>";
+
+// XMLPrinterHTML5 is small enough, just put the entire implementation inline.
+class	XMLPrinterHTML5 : public XMLPrinter
+{
+public:
+    XMLPrinterHTML5 (FILE* file=0, bool compact = false, int depth = 0) :
+        XMLPrinter (file, compact, depth)
+    {}
+
+protected:
+    virtual void CloseElement () {
+        if (_elementJustOpened && !isVoidElement (_stack.PeekTop())) {
+            SealElement();
+            }
+        XMLPrinter::CloseElement();
+    }
+
+    virtual bool isVoidElement (const char *name) {
+// Complete list of all HTML5 "void elements",
+// http://dev.w3.org/html5/markup/syntax.html
+        static const char *list[] = {
+            "area", "base", "br", "col", "command", "embed", "hr", "img",
+            "input", "keygen", "link", "meta", "param", "source", "track", "wbr",
+            NULL
+        };
+
+// I could use 'bsearch', but I don't have MSVC to test on (it would work with gcc/libc).
+        for (const char **p = list; *p; ++p) {
+            if (!strcasecmp (name, *p)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+};
+
+int	main (void) {
+    XMLDocument doc (false);
+    doc.Parse (input);
+
+    std::cout << "INPUT:\n" << input << "\n\n";
+
+    XMLPrinter prn (NULL, true);
+    doc.Print (&prn);
+    std::cout << "XMLPrinter (not valid HTML5):\n" << prn.CStr() << "\n\n";
+
+    XMLPrinterHTML5 html5 (NULL, true);
+    doc.Print (&html5);
+    std::cout << "XMLPrinterHTML5:\n" << html5.CStr() << "\n";
+
+    return 0;
+}

--- a/tinyxml2-3.0.0/readme.md
+++ b/tinyxml2-3.0.0/readme.md
@@ -1,0 +1,324 @@
+TinyXML-2
+=========
+![TinyXML-2 Logo](http://www.grinninglizard.com/tinyxml2/TinyXML2_small.png)
+
+TinyXML-2 is a simple, small, efficient, C++ XML parser that can be 
+easily integrated into other programs.
+
+The master is hosted on github:
+https://github.com/leethomason/tinyxml2
+
+The online HTML version of these docs:
+http://grinninglizard.com/tinyxml2docs/index.html
+
+Examples are in the "related pages" tab of the HTML docs.
+
+What it does.
+-------------
+	
+In brief, TinyXML-2 parses an XML document, and builds from that a 
+Document Object Model (DOM) that can be read, modified, and saved.
+
+XML stands for "eXtensible Markup Language." It is a general purpose
+human and machine readable markup language to describe arbitrary data.
+All those random file formats created to store application data can 
+all be replaced with XML. One parser for everything.
+
+http://en.wikipedia.org/wiki/XML
+
+There are different ways to access and interact with XML data.
+TinyXML-2 uses a Document Object Model (DOM), meaning the XML data is parsed
+into a C++ objects that can be browsed and manipulated, and then 
+written to disk or another output stream. You can also construct an XML document 
+from scratch with C++ objects and write this to disk or another output
+stream. You can even use TinyXML-2 to stream XML programmatically from
+code without creating a document first.
+
+TinyXML-2 is designed to be easy and fast to learn. It is one header and
+one cpp file. Simply add these to your project and off you go. 
+There is an example file - xmltest.cpp - to get you started. 
+
+TinyXML-2 is released under the ZLib license, 
+so you can use it in open source or commercial code. The details
+of the license are at the top of every source file.
+
+TinyXML-2 attempts to be a flexible parser, but with truly correct and
+compliant XML output. TinyXML-2 should compile on any reasonably C++
+compliant system. It does not rely on exceptions, RTTI, or the STL.
+
+What it doesn't do.
+-------------------
+
+TinyXML-2 doesn't parse or use DTDs (Document Type Definitions) or XSLs
+(eXtensible Stylesheet Language.) There are other parsers out there 
+that are much more fully featured. But they are also much bigger, 
+take longer to set up in your project, have a higher learning curve, 
+and often have a more restrictive license. If you are working with 
+browsers or have more complete XML needs, TinyXML-2 is not the parser for you.
+
+TinyXML-1 vs. TinyXML-2
+-----------------------
+
+TinyXML-2 is now the focus of all development, well tested, and your
+best choice unless you have a requirement to maintain TinyXML-1 code.
+
+TinyXML-2 uses a similar API to TinyXML-1 and the same
+rich test cases. But the implementation of the parser is completely re-written
+to make it more appropriate for use in a game. It uses less memory, is faster,
+and uses far fewer memory allocations.
+
+TinyXML-2 has no requirement for STL, but has also dropped all STL support. All
+strings are query and set as 'const char*'. This allows the use of internal 
+allocators, and keeps the code much simpler.
+
+Both parsers:
+
+1.  Simple to use with similar APIs.
+2.  DOM based parser.
+3.  UTF-8 Unicode support. http://en.wikipedia.org/wiki/UTF-8
+
+Advantages of TinyXML-2
+
+1.  The focus of all future dev.
+2.  Many fewer memory allocation (1/10th to 1/100th), uses less memory
+    (about 40% of TinyXML-1), and faster.
+3.  No STL requirement.
+4.  More modern C++, including a proper namespace.
+5.  Proper and useful handling of whitespace
+
+Advantages of TinyXML-1
+
+1.  Can report the location of parsing errors.
+2.  Support for some C++ STL conventions: streams and strings
+3.  Very mature and well debugged code base.
+
+Features
+--------
+
+### Memory Model
+
+An XMLDocument is a C++ object like any other, that can be on the stack, or
+new'd and deleted on the heap.
+
+However, any sub-node of the Document, XMLElement, XMLText, etc, can only
+be created by calling the appropriate XMLDocument::NewElement, NewText, etc.
+method. Although you have pointers to these objects, they are still owned
+by the Document. When the Document is deleted, so are all the nodes it contains.
+
+### White Space
+
+#### Whitespace Preservation (default)
+
+Microsoft has an excellent article on white space: http://msdn.microsoft.com/en-us/library/ms256097.aspx
+
+By default, TinyXML-2 preserves white space in a (hopefully) sane way that is almost complient with the
+spec. (TinyXML-1 used a completely different model, much more similar to 'collapse', below.)
+
+As a first step, all newlines / carriage-returns / line-feeds are normalized to a
+line-feed character, as required by the XML spec.
+
+White space in text is preserved. For example:
+
+	<element> Hello,  World</element>
+
+The leading space before the "Hello" and the double space after the comma are 
+preserved. Line-feeds are preserved, as in this example:
+
+	<element> Hello again,  
+	          World</element>
+
+However, white space between elements is **not** preserved. Although not strictly 
+compliant, tracking and reporting inter-element space is awkward, and not normally
+valuable. TinyXML-2 sees these as the same XML:
+
+	<document>
+		<data>1</data>
+		<data>2</data>
+		<data>3</data>
+	</document>
+
+	<document><data>1</data><data>2</data><data>3</data></document>
+
+#### Whitespace Collapse
+
+For some applications, it is preferable to collapse whitespace. Collapsing
+whitespace gives you "HTML-like" behavior, which is sometimes more suitable
+for hand typed documents. 
+
+TinyXML-2 supports this with the 'whitespace' parameter to the XMLDocument constructor.
+(The default is to preserve whitespace, as described above.)
+
+However, you may also use COLLAPSE_WHITESPACE, which will:
+
+* Remove leading and trailing whitespace
+* Convert newlines and line-feeds into a space character
+* Collapse a run of any number of space characters into a single space character
+
+Note that (currently) there is a performance impact for using COLLAPSE_WHITESPACE.
+It essentially causes the XML to be parsed twice.
+
+### Entities
+
+TinyXML-2 recognizes the pre-defined "character entities", meaning special
+characters. Namely:
+
+	&amp;	&
+	&lt;	<
+	&gt;	>
+	&quot;	"
+	&apos;	'
+
+These are recognized when the XML document is read, and translated to their
+UTF-8 equivalents. For instance, text with the XML of:
+
+	Far &amp; Away
+
+will have the Value() of "Far & Away" when queried from the XMLText object,
+and will be written back to the XML stream/file as an ampersand. 
+
+Additionally, any character can be specified by its Unicode code point:
+The syntax "&#xA0;" or "&#160;" are both to the non-breaking space characher. 
+This is called a 'numeric character reference'. Any numeric character reference
+that isn't one of the special entities above, will be read, but written as a
+regular code point. The output is correct, but the entity syntax isn't preserved.
+
+### Printing
+
+#### Print to file
+You can directly use the convenience function:
+
+	XMLDocument doc;
+	...
+	doc.SaveFile( "foo.xml" );
+
+Or the XMLPrinter class:
+
+	XMLPrinter printer( fp );
+	doc.Print( &printer );
+
+#### Print to memory
+Printing to memory is supported by the XMLPrinter.
+
+	XMLPrinter printer;
+	doc.Print( &printer );
+	// printer.CStr() has a const char* to the XML
+
+#### Print without an XMLDocument
+
+When loading, an XML parser is very useful. However, sometimes
+when saving, it just gets in the way. The code is often set up
+for streaming, and constructing the DOM is just overhead.
+
+The Printer supports the streaming case. The following code
+prints out a trivially simple XML file without ever creating
+an XML document.
+
+	XMLPrinter printer( fp );
+	printer.OpenElement( "foo" );
+	printer.PushAttribute( "foo", "bar" );
+	printer.CloseElement();
+
+Examples
+--------
+
+#### Load and parse an XML file.
+
+	/* ------ Example 1: Load and parse an XML file. ---- */	
+	{
+		XMLDocument doc;
+		doc.LoadFile( "dream.xml" );
+	}
+
+#### Lookup information.
+
+	/* ------ Example 2: Lookup information. ---- */	
+	{
+		XMLDocument doc;
+		doc.LoadFile( "dream.xml" );
+
+		// Structure of the XML file:
+		// - Element "PLAY"      the root Element, which is the 
+		//                       FirstChildElement of the Document
+		// - - Element "TITLE"   child of the root PLAY Element
+		// - - - Text            child of the TITLE Element
+		
+		// Navigate to the title, using the convenience function,
+		// with a dangerous lack of error checking.
+		const char* title = doc.FirstChildElement( "PLAY" )->FirstChildElement( "TITLE" )->GetText();
+		printf( "Name of play (1): %s\n", title );
+		
+		// Text is just another Node to TinyXML-2. The more
+		// general way to get to the XMLText:
+		XMLText* textNode = doc.FirstChildElement( "PLAY" )->FirstChildElement( "TITLE" )->FirstChild()->ToText();
+		title = textNode->Value();
+		printf( "Name of play (2): %s\n", title );
+	}
+
+Using and Installing
+--------------------
+
+There are 2 files in TinyXML-2:
+* tinyxml2.cpp
+* tinyxml2.h
+
+And additionally a test file:
+* xmltest.cpp
+
+Simply compile and run. There is a visual studio 2010 project included, a simple Makefile, 
+an XCode project, a Code::Blocks project, and a cmake CMakeLists.txt included to help you. 
+The top of tinyxml.h even has a simple g++ command line if you are are *nix and don't want 
+to use a build system.
+
+Versioning
+----------
+
+TinyXML-2 uses semantic versioning. http://semver.org/ Releases are now tagged in github.
+
+Note that the major version will (probably) change fairly rapidly. API changes are fairly
+common.
+
+Documentation
+-------------
+
+The documentation is build with Doxygen, using the 'dox' 
+configuration file.
+
+License
+-------
+
+TinyXML-2 is released under the zlib license:
+
+This software is provided 'as-is', without any express or implied 
+warranty. In no event will the authors be held liable for any 
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any 
+purpose, including commercial applications, and to alter it and 
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must 
+not claim that you wrote the original software. If you use this 
+software in a product, an acknowledgment in the product documentation 
+would be appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and 
+must not be misrepresented as being the original software.
+3. This notice may not be removed or altered from any source 
+distribution.
+
+Contributors
+------------
+
+Thanks very much to everyone who sends suggestions, bugs, ideas, and 
+encouragement. It all helps, and makes this project fun.
+
+The original TinyXML-1 has many contributors, who all deserve thanks
+in shaping what is a very successful library. Extra thanks to Yves
+Berquin and Andrew Ellerton who were key contributors.
+
+TinyXML-2 grew from that effort. Lee Thomason is the original author
+of TinyXML-2 (and TinyXML-1) but TinyXML-2 has been and is being improved
+by many contributors.
+
+Thanks to John Mackay at http://john.mackay.rosalilastudio.com for the TinyXML-2 logo!
+
+

--- a/tinyxml2-3.0.0/resources/dream.xml
+++ b/tinyxml2-3.0.0/resources/dream.xml
@@ -1,0 +1,4546 @@
+<?xml version="1.0"?>
+<!DOCTYPE PLAY SYSTEM "play.dtd">
+
+<PLAY>
+<TITLE>A Midsummer Night's Dream</TITLE>
+
+<FM>
+<P>Text placed in the public domain by Moby Lexical Tools, 1992.</P>
+<P>SGML markup by Jon Bosak, 1992-1994.</P>
+<P>XML version by Jon Bosak, 1996-1998.</P>
+<P>This work may be freely copied and distributed worldwide.</P>
+</FM>
+
+
+<PERSONAE>
+<TITLE>Dramatis Personae</TITLE>
+
+<PERSONA>THESEUS, Duke of Athens.</PERSONA>
+<PERSONA>EGEUS, father to Hermia.</PERSONA>
+
+<PGROUP>
+<PERSONA>LYSANDER</PERSONA>
+<PERSONA>DEMETRIUS</PERSONA>
+<GRPDESCR>in love with Hermia.</GRPDESCR>
+</PGROUP>
+
+<PERSONA>PHILOSTRATE, master of the revels to Theseus.</PERSONA>
+<PERSONA>QUINCE, a carpenter.</PERSONA>
+<PERSONA>SNUG, a joiner.</PERSONA>
+<PERSONA>BOTTOM, a weaver.</PERSONA>
+<PERSONA>FLUTE, a bellows-mender.</PERSONA>
+<PERSONA>SNOUT, a tinker.</PERSONA>
+<PERSONA>STARVELING, a tailor.</PERSONA>
+<PERSONA>HIPPOLYTA, queen of the Amazons, betrothed to Theseus.</PERSONA>
+<PERSONA>HERMIA, daughter to Egeus, in love with Lysander.</PERSONA>
+<PERSONA>HELENA, in love with Demetrius.</PERSONA>
+<PERSONA>OBERON, king of the fairies.</PERSONA>
+<PERSONA>TITANIA, queen of the fairies.</PERSONA>
+<PERSONA>PUCK, or Robin Goodfellow.</PERSONA>
+
+<PGROUP>
+<PERSONA>PEASEBLOSSOM</PERSONA>
+<PERSONA>COBWEB</PERSONA>
+<PERSONA>MOTH</PERSONA>
+<PERSONA>MUSTARDSEED</PERSONA>
+<GRPDESCR>fairies.</GRPDESCR>
+</PGROUP>
+
+<PERSONA>Other fairies attending their King and Queen.</PERSONA>
+<PERSONA>Attendants on Theseus and Hippolyta.</PERSONA>
+</PERSONAE>
+
+<SCNDESCR>SCENE  Athens, and a wood near it.</SCNDESCR>
+
+<PLAYSUBT>A MIDSUMMER NIGHT'S DREAM</PLAYSUBT>
+
+<ACT><TITLE>ACT I</TITLE>
+
+<SCENE><TITLE>SCENE I.  Athens. The palace of THESEUS.</TITLE>
+<STAGEDIR>Enter THESEUS, HIPPOLYTA, PHILOSTRATE, and
+Attendants</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Now, fair Hippolyta, our nuptial hour</LINE>
+<LINE>Draws on apace; four happy days bring in</LINE>
+<LINE>Another moon: but, O, methinks, how slow</LINE>
+<LINE>This old moon wanes! she lingers my desires,</LINE>
+<LINE>Like to a step-dame or a dowager</LINE>
+<LINE>Long withering out a young man revenue.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>Four days will quickly steep themselves in night;</LINE>
+<LINE>Four nights will quickly dream away the time;</LINE>
+<LINE>And then the moon, like to a silver bow</LINE>
+<LINE>New-bent in heaven, shall behold the night</LINE>
+<LINE>Of our solemnities.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Go, Philostrate,</LINE>
+<LINE>Stir up the Athenian youth to merriments;</LINE>
+<LINE>Awake the pert and nimble spirit of mirth;</LINE>
+<LINE>Turn melancholy forth to funerals;</LINE>
+<LINE>The pale companion is not for our pomp.</LINE>
+<STAGEDIR>Exit PHILOSTRATE</STAGEDIR>
+<LINE>Hippolyta, I woo'd thee with my sword,</LINE>
+<LINE>And won thy love, doing thee injuries;</LINE>
+<LINE>But I will wed thee in another key,</LINE>
+<LINE>With pomp, with triumph and with revelling.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter EGEUS, HERMIA, LYSANDER, and DEMETRIUS</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>EGEUS</SPEAKER>
+<LINE>Happy be Theseus, our renowned duke!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Thanks, good Egeus: what's the news with thee?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>EGEUS</SPEAKER>
+<LINE>Full of vexation come I, with complaint</LINE>
+<LINE>Against my child, my daughter Hermia.</LINE>
+<LINE>Stand forth, Demetrius. My noble lord,</LINE>
+<LINE>This man hath my consent to marry her.</LINE>
+<LINE>Stand forth, Lysander: and my gracious duke,</LINE>
+<LINE>This man hath bewitch'd the bosom of my child;</LINE>
+<LINE>Thou, thou, Lysander, thou hast given her rhymes,</LINE>
+<LINE>And interchanged love-tokens with my child:</LINE>
+<LINE>Thou hast by moonlight at her window sung,</LINE>
+<LINE>With feigning voice verses of feigning love,</LINE>
+<LINE>And stolen the impression of her fantasy</LINE>
+<LINE>With bracelets of thy hair, rings, gawds, conceits,</LINE>
+<LINE>Knacks, trifles, nosegays, sweetmeats, messengers</LINE>
+<LINE>Of strong prevailment in unharden'd youth:</LINE>
+<LINE>With cunning hast thou filch'd my daughter's heart,</LINE>
+<LINE>Turn'd her obedience, which is due to me,</LINE>
+<LINE>To stubborn harshness: and, my gracious duke,</LINE>
+<LINE>Be it so she; will not here before your grace</LINE>
+<LINE>Consent to marry with Demetrius,</LINE>
+<LINE>I beg the ancient privilege of Athens,</LINE>
+<LINE>As she is mine, I may dispose of her:</LINE>
+<LINE>Which shall be either to this gentleman</LINE>
+<LINE>Or to her death, according to our law</LINE>
+<LINE>Immediately provided in that case.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>What say you, Hermia? be advised fair maid:</LINE>
+<LINE>To you your father should be as a god;</LINE>
+<LINE>One that composed your beauties, yea, and one</LINE>
+<LINE>To whom you are but as a form in wax</LINE>
+<LINE>By him imprinted and within his power</LINE>
+<LINE>To leave the figure or disfigure it.</LINE>
+<LINE>Demetrius is a worthy gentleman.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>So is Lysander.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>In himself he is;</LINE>
+<LINE>But in this kind, wanting your father's voice,</LINE>
+<LINE>The other must be held the worthier.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>I would my father look'd but with my eyes.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Rather your eyes must with his judgment look.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>I do entreat your grace to pardon me.</LINE>
+<LINE>I know not by what power I am made bold,</LINE>
+<LINE>Nor how it may concern my modesty,</LINE>
+<LINE>In such a presence here to plead my thoughts;</LINE>
+<LINE>But I beseech your grace that I may know</LINE>
+<LINE>The worst that may befall me in this case,</LINE>
+<LINE>If I refuse to wed Demetrius.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Either to die the death or to abjure</LINE>
+<LINE>For ever the society of men.</LINE>
+<LINE>Therefore, fair Hermia, question your desires;</LINE>
+<LINE>Know of your youth, examine well your blood,</LINE>
+<LINE>Whether, if you yield not to your father's choice,</LINE>
+<LINE>You can endure the livery of a nun,</LINE>
+<LINE>For aye to be in shady cloister mew'd,</LINE>
+<LINE>To live a barren sister all your life,</LINE>
+<LINE>Chanting faint hymns to the cold fruitless moon.</LINE>
+<LINE>Thrice-blessed they that master so their blood,</LINE>
+<LINE>To undergo such maiden pilgrimage;</LINE>
+<LINE>But earthlier happy is the rose distill'd,</LINE>
+<LINE>Than that which withering on the virgin thorn</LINE>
+<LINE>Grows, lives and dies in single blessedness.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>So will I grow, so live, so die, my lord,</LINE>
+<LINE>Ere I will my virgin patent up</LINE>
+<LINE>Unto his lordship, whose unwished yoke</LINE>
+<LINE>My soul consents not to give sovereignty.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Take time to pause; and, by the nest new moon--</LINE>
+<LINE>The sealing-day betwixt my love and me,</LINE>
+<LINE>For everlasting bond of fellowship--</LINE>
+<LINE>Upon that day either prepare to die</LINE>
+<LINE>For disobedience to your father's will,</LINE>
+<LINE>Or else to wed Demetrius, as he would;</LINE>
+<LINE>Or on Diana's altar to protest</LINE>
+<LINE>For aye austerity and single life.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Relent, sweet Hermia: and, Lysander, yield</LINE>
+<LINE>Thy crazed title to my certain right.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>You have her father's love, Demetrius;</LINE>
+<LINE>Let me have Hermia's: do you marry him.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>EGEUS</SPEAKER>
+<LINE>Scornful Lysander! true, he hath my love,</LINE>
+<LINE>And what is mine my love shall render him.</LINE>
+<LINE>And she is mine, and all my right of her</LINE>
+<LINE>I do estate unto Demetrius.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>I am, my lord, as well derived as he,</LINE>
+<LINE>As well possess'd; my love is more than his;</LINE>
+<LINE>My fortunes every way as fairly rank'd,</LINE>
+<LINE>If not with vantage, as Demetrius';</LINE>
+<LINE>And, which is more than all these boasts can be,</LINE>
+<LINE>I am beloved of beauteous Hermia:</LINE>
+<LINE>Why should not I then prosecute my right?</LINE>
+<LINE>Demetrius, I'll avouch it to his head,</LINE>
+<LINE>Made love to Nedar's daughter, Helena,</LINE>
+<LINE>And won her soul; and she, sweet lady, dotes,</LINE>
+<LINE>Devoutly dotes, dotes in idolatry,</LINE>
+<LINE>Upon this spotted and inconstant man.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>I must confess that I have heard so much,</LINE>
+<LINE>And with Demetrius thought to have spoke thereof;</LINE>
+<LINE>But, being over-full of self-affairs,</LINE>
+<LINE>My mind did lose it. But, Demetrius, come;</LINE>
+<LINE>And come, Egeus; you shall go with me,</LINE>
+<LINE>I have some private schooling for you both.</LINE>
+<LINE>For you, fair Hermia, look you arm yourself</LINE>
+<LINE>To fit your fancies to your father's will;</LINE>
+<LINE>Or else the law of Athens yields you up--</LINE>
+<LINE>Which by no means we may extenuate--</LINE>
+<LINE>To death, or to a vow of single life.</LINE>
+<LINE>Come, my Hippolyta: what cheer, my love?</LINE>
+<LINE>Demetrius and Egeus, go along:</LINE>
+<LINE>I must employ you in some business</LINE>
+<LINE>Against our nuptial and confer with you</LINE>
+<LINE>Of something nearly that concerns yourselves.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>EGEUS</SPEAKER>
+<LINE>With duty and desire we follow you.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt all but LYSANDER and HERMIA</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>How now, my love! why is your cheek so pale?</LINE>
+<LINE>How chance the roses there do fade so fast?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Belike for want of rain, which I could well</LINE>
+<LINE>Beteem them from the tempest of my eyes.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Ay me! for aught that I could ever read,</LINE>
+<LINE>Could ever hear by tale or history,</LINE>
+<LINE>The course of true love never did run smooth;</LINE>
+<LINE>But, either it was different in blood,--</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>O cross! too high to be enthrall'd to low.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Or else misgraffed in respect of years,--</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>O spite! too old to be engaged to young.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Or else it stood upon the choice of friends,--</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>O hell! to choose love by another's eyes.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Or, if there were a sympathy in choice,</LINE>
+<LINE>War, death, or sickness did lay siege to it,</LINE>
+<LINE>Making it momentany as a sound,</LINE>
+<LINE>Swift as a shadow, short as any dream;</LINE>
+<LINE>Brief as the lightning in the collied night,</LINE>
+<LINE>That, in a spleen, unfolds both heaven and earth,</LINE>
+<LINE>And ere a man hath power to say 'Behold!'</LINE>
+<LINE>The jaws of darkness do devour it up:</LINE>
+<LINE>So quick bright things come to confusion.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>If then true lovers have been ever cross'd,</LINE>
+<LINE>It stands as an edict in destiny:</LINE>
+<LINE>Then let us teach our trial patience,</LINE>
+<LINE>Because it is a customary cross,</LINE>
+<LINE>As due to love as thoughts and dreams and sighs,</LINE>
+<LINE>Wishes and tears, poor fancy's followers.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>A good persuasion: therefore, hear me, Hermia.</LINE>
+<LINE>I have a widow aunt, a dowager</LINE>
+<LINE>Of great revenue, and she hath no child:</LINE>
+<LINE>From Athens is her house remote seven leagues;</LINE>
+<LINE>And she respects me as her only son.</LINE>
+<LINE>There, gentle Hermia, may I marry thee;</LINE>
+<LINE>And to that place the sharp Athenian law</LINE>
+<LINE>Cannot pursue us. If thou lovest me then,</LINE>
+<LINE>Steal forth thy father's house to-morrow night;</LINE>
+<LINE>And in the wood, a league without the town,</LINE>
+<LINE>Where I did meet thee once with Helena,</LINE>
+<LINE>To do observance to a morn of May,</LINE>
+<LINE>There will I stay for thee.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>My good Lysander!</LINE>
+<LINE>I swear to thee, by Cupid's strongest bow,</LINE>
+<LINE>By his best arrow with the golden head,</LINE>
+<LINE>By the simplicity of Venus' doves,</LINE>
+<LINE>By that which knitteth souls and prospers loves,</LINE>
+<LINE>And by that fire which burn'd the Carthage queen,</LINE>
+<LINE>When the false Troyan under sail was seen,</LINE>
+<LINE>By all the vows that ever men have broke,</LINE>
+<LINE>In number more than ever women spoke,</LINE>
+<LINE>In that same place thou hast appointed me,</LINE>
+<LINE>To-morrow truly will I meet with thee.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Keep promise, love. Look, here comes Helena.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter HELENA</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>God speed fair Helena! whither away?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Call you me fair? that fair again unsay.</LINE>
+<LINE>Demetrius loves your fair: O happy fair!</LINE>
+<LINE>Your eyes are lode-stars; and your tongue's sweet air</LINE>
+<LINE>More tuneable than lark to shepherd's ear,</LINE>
+<LINE>When wheat is green, when hawthorn buds appear.</LINE>
+<LINE>Sickness is catching: O, were favour so,</LINE>
+<LINE>Yours would I catch, fair Hermia, ere I go;</LINE>
+<LINE>My ear should catch your voice, my eye your eye,</LINE>
+<LINE>My tongue should catch your tongue's sweet melody.</LINE>
+<LINE>Were the world mine, Demetrius being bated,</LINE>
+<LINE>The rest I'd give to be to you translated.</LINE>
+<LINE>O, teach me how you look, and with what art</LINE>
+<LINE>You sway the motion of Demetrius' heart.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>I frown upon him, yet he loves me still.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>O that your frowns would teach my smiles such skill!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>I give him curses, yet he gives me love.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>O that my prayers could such affection move!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>The more I hate, the more he follows me.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>The more I love, the more he hateth me.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>His folly, Helena, is no fault of mine.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>None, but your beauty: would that fault were mine!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Take comfort: he no more shall see my face;</LINE>
+<LINE>Lysander and myself will fly this place.</LINE>
+<LINE>Before the time I did Lysander see,</LINE>
+<LINE>Seem'd Athens as a paradise to me:</LINE>
+<LINE>O, then, what graces in my love do dwell,</LINE>
+<LINE>That he hath turn'd a heaven unto a hell!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Helen, to you our minds we will unfold:</LINE>
+<LINE>To-morrow night, when Phoebe doth behold</LINE>
+<LINE>Her silver visage in the watery glass,</LINE>
+<LINE>Decking with liquid pearl the bladed grass,</LINE>
+<LINE>A time that lovers' flights doth still conceal,</LINE>
+<LINE>Through Athens' gates have we devised to steal.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>And in the wood, where often you and I</LINE>
+<LINE>Upon faint primrose-beds were wont to lie,</LINE>
+<LINE>Emptying our bosoms of their counsel sweet,</LINE>
+<LINE>There my Lysander and myself shall meet;</LINE>
+<LINE>And thence from Athens turn away our eyes,</LINE>
+<LINE>To seek new friends and stranger companies.</LINE>
+<LINE>Farewell, sweet playfellow: pray thou for us;</LINE>
+<LINE>And good luck grant thee thy Demetrius!</LINE>
+<LINE>Keep word, Lysander: we must starve our sight</LINE>
+<LINE>From lovers' food till morrow deep midnight.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>I will, my Hermia.</LINE>
+<STAGEDIR>Exit HERMIA</STAGEDIR>
+<LINE>Helena, adieu:</LINE>
+<LINE>As you on him, Demetrius dote on you!</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>How happy some o'er other some can be!</LINE>
+<LINE>Through Athens I am thought as fair as she.</LINE>
+<LINE>But what of that? Demetrius thinks not so;</LINE>
+<LINE>He will not know what all but he do know:</LINE>
+<LINE>And as he errs, doting on Hermia's eyes,</LINE>
+<LINE>So I, admiring of his qualities:</LINE>
+<LINE>Things base and vile, folding no quantity,</LINE>
+<LINE>Love can transpose to form and dignity:</LINE>
+<LINE>Love looks not with the eyes, but with the mind;</LINE>
+<LINE>And therefore is wing'd Cupid painted blind:</LINE>
+<LINE>Nor hath Love's mind of any judgement taste;</LINE>
+<LINE>Wings and no eyes figure unheedy haste:</LINE>
+<LINE>And therefore is Love said to be a child,</LINE>
+<LINE>Because in choice he is so oft beguiled.</LINE>
+<LINE>As waggish boys in game themselves forswear,</LINE>
+<LINE>So the boy Love is perjured every where:</LINE>
+<LINE>For ere Demetrius look'd on Hermia's eyne,</LINE>
+<LINE>He hail'd down oaths that he was only mine;</LINE>
+<LINE>And when this hail some heat from Hermia felt,</LINE>
+<LINE>So he dissolved, and showers of oaths did melt.</LINE>
+<LINE>I will go tell him of fair Hermia's flight:</LINE>
+<LINE>Then to the wood will he to-morrow night</LINE>
+<LINE>Pursue her; and for this intelligence</LINE>
+<LINE>If I have thanks, it is a dear expense:</LINE>
+<LINE>But herein mean I to enrich my pain,</LINE>
+<LINE>To have his sight thither and back again.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+</SCENE>
+
+<SCENE><TITLE>SCENE II.  Athens. QUINCE'S house.</TITLE>
+<STAGEDIR>Enter QUINCE, SNUG, BOTTOM, FLUTE, SNOUT, and
+STARVELING</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Is all our company here?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>You were best to call them generally, man by man,</LINE>
+<LINE>according to the scrip.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Here is the scroll of every man's name, which is</LINE>
+<LINE>thought fit, through all Athens, to play in our</LINE>
+<LINE>interlude before the duke and the duchess, on his</LINE>
+<LINE>wedding-day at night.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>First, good Peter Quince, say what the play treats</LINE>
+<LINE>on, then read the names of the actors, and so grow</LINE>
+<LINE>to a point.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Marry, our play is, The most lamentable comedy, and</LINE>
+<LINE>most cruel death of Pyramus and Thisby.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>A very good piece of work, I assure you, and a</LINE>
+<LINE>merry. Now, good Peter Quince, call forth your</LINE>
+<LINE>actors by the scroll. Masters, spread yourselves.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Answer as I call you. Nick Bottom, the weaver.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Ready. Name what part I am for, and proceed.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>You, Nick Bottom, are set down for Pyramus.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>What is Pyramus? a lover, or a tyrant?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>A lover, that kills himself most gallant for love.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>That will ask some tears in the true performing of</LINE>
+<LINE>it: if I do it, let the audience look to their</LINE>
+<LINE>eyes; I will move storms, I will condole in some</LINE>
+<LINE>measure. To the rest: yet my chief humour is for a</LINE>
+<LINE>tyrant: I could play Ercles rarely, or a part to</LINE>
+<LINE>tear a cat in, to make all split.</LINE>
+<LINE>The raging rocks</LINE>
+<LINE>And shivering shocks</LINE>
+<LINE>Shall break the locks</LINE>
+<LINE>Of prison gates;</LINE>
+<LINE>And Phibbus' car</LINE>
+<LINE>Shall shine from far</LINE>
+<LINE>And make and mar</LINE>
+<LINE>The foolish Fates.</LINE>
+<LINE>This was lofty! Now name the rest of the players.</LINE>
+<LINE>This is Ercles' vein, a tyrant's vein; a lover is</LINE>
+<LINE>more condoling.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Francis Flute, the bellows-mender.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>Here, Peter Quince.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Flute, you must take Thisby on you.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>What is Thisby? a wandering knight?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>It is the lady that Pyramus must love.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>Nay, faith, let me not play a woman; I have a beard coming.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>That's all one: you shall play it in a mask, and</LINE>
+<LINE>you may speak as small as you will.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>An I may hide my face, let me play Thisby too, I'll</LINE>
+<LINE>speak in a monstrous little voice. 'Thisne,</LINE>
+<LINE>Thisne;' 'Ah, Pyramus, lover dear! thy Thisby dear,</LINE>
+<LINE>and lady dear!'</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>No, no; you must play Pyramus: and, Flute, you Thisby.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Well, proceed.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Robin Starveling, the tailor.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>STARVELING</SPEAKER>
+<LINE>Here, Peter Quince.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Robin Starveling, you must play Thisby's mother.</LINE>
+<LINE>Tom Snout, the tinker.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>SNOUT</SPEAKER>
+<LINE>Here, Peter Quince.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>You, Pyramus' father: myself, Thisby's father:</LINE>
+<LINE>Snug, the joiner; you, the lion's part: and, I</LINE>
+<LINE>hope, here is a play fitted.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>SNUG</SPEAKER>
+<LINE>Have you the lion's part written? pray you, if it</LINE>
+<LINE>be, give it me, for I am slow of study.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>You may do it extempore, for it is nothing but roaring.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Let me play the lion too: I will roar, that I will</LINE>
+<LINE>do any man's heart good to hear me; I will roar,</LINE>
+<LINE>that I will make the duke say 'Let him roar again,</LINE>
+<LINE>let him roar again.'</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>An you should do it too terribly, you would fright</LINE>
+<LINE>the duchess and the ladies, that they would shriek;</LINE>
+<LINE>and that were enough to hang us all.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>ALL</SPEAKER>
+<LINE>That would hang us, every mother's son.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>I grant you, friends, if that you should fright the</LINE>
+<LINE>ladies out of their wits, they would have no more</LINE>
+<LINE>discretion but to hang us: but I will aggravate my</LINE>
+<LINE>voice so that I will roar you as gently as any</LINE>
+<LINE>sucking dove; I will roar you an 'twere any</LINE>
+<LINE>nightingale.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>You can play no part but Pyramus; for Pyramus is a</LINE>
+<LINE>sweet-faced man; a proper man, as one shall see in a</LINE>
+<LINE>summer's day; a most lovely gentleman-like man:</LINE>
+<LINE>therefore you must needs play Pyramus.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Well, I will undertake it. What beard were I best</LINE>
+<LINE>to play it in?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Why, what you will.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>I will discharge it in either your straw-colour</LINE>
+<LINE>beard, your orange-tawny beard, your purple-in-grain</LINE>
+<LINE>beard, or your French-crown-colour beard, your</LINE>
+<LINE>perfect yellow.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Some of your French crowns have no hair at all, and</LINE>
+<LINE>then you will play bare-faced. But, masters, here</LINE>
+<LINE>are your parts: and I am to entreat you, request</LINE>
+<LINE>you and desire you, to con them by to-morrow night;</LINE>
+<LINE>and meet me in the palace wood, a mile without the</LINE>
+<LINE>town, by moonlight; there will we rehearse, for if</LINE>
+<LINE>we meet in the city, we shall be dogged with</LINE>
+<LINE>company, and our devices known. In the meantime I</LINE>
+<LINE>will draw a bill of properties, such as our play</LINE>
+<LINE>wants. I pray you, fail me not.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>We will meet; and there we may rehearse most</LINE>
+<LINE>obscenely and courageously. Take pains; be perfect: adieu.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>At the duke's oak we meet.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Enough; hold or cut bow-strings.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt</STAGEDIR>
+</SCENE>
+
+</ACT>
+
+<ACT><TITLE>ACT II</TITLE>
+
+<SCENE><TITLE>SCENE I.  A wood near Athens.</TITLE>
+<STAGEDIR>Enter, from opposite sides, a Fairy, and PUCK</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>How now, spirit! whither wander you?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Fairy</SPEAKER>
+<LINE>Over hill, over dale,</LINE>
+<LINE>Thorough bush, thorough brier,</LINE>
+<LINE>Over park, over pale,</LINE>
+<LINE>Thorough flood, thorough fire,</LINE>
+<LINE>I do wander everywhere,</LINE>
+<LINE>Swifter than the moon's sphere;</LINE>
+<LINE>And I serve the fairy queen,</LINE>
+<LINE>To dew her orbs upon the green.</LINE>
+<LINE>The cowslips tall her pensioners be:</LINE>
+<LINE>In their gold coats spots you see;</LINE>
+<LINE>Those be rubies, fairy favours,</LINE>
+<LINE>In those freckles live their savours:</LINE>
+<LINE>I must go seek some dewdrops here</LINE>
+<LINE>And hang a pearl in every cowslip's ear.</LINE>
+<LINE>Farewell, thou lob of spirits; I'll be gone:</LINE>
+<LINE>Our queen and all our elves come here anon.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>The king doth keep his revels here to-night:</LINE>
+<LINE>Take heed the queen come not within his sight;</LINE>
+<LINE>For Oberon is passing fell and wrath,</LINE>
+<LINE>Because that she as her attendant hath</LINE>
+<LINE>A lovely boy, stolen from an Indian king;</LINE>
+<LINE>She never had so sweet a changeling;</LINE>
+<LINE>And jealous Oberon would have the child</LINE>
+<LINE>Knight of his train, to trace the forests wild;</LINE>
+<LINE>But she perforce withholds the loved boy,</LINE>
+<LINE>Crowns him with flowers and makes him all her joy:</LINE>
+<LINE>And now they never meet in grove or green,</LINE>
+<LINE>By fountain clear, or spangled starlight sheen,</LINE>
+<LINE>But, they do square, that all their elves for fear</LINE>
+<LINE>Creep into acorn-cups and hide them there.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Fairy</SPEAKER>
+<LINE>Either I mistake your shape and making quite,</LINE>
+<LINE>Or else you are that shrewd and knavish sprite</LINE>
+<LINE>Call'd Robin Goodfellow: are not you he</LINE>
+<LINE>That frights the maidens of the villagery;</LINE>
+<LINE>Skim milk, and sometimes labour in the quern</LINE>
+<LINE>And bootless make the breathless housewife churn;</LINE>
+<LINE>And sometime make the drink to bear no barm;</LINE>
+<LINE>Mislead night-wanderers, laughing at their harm?</LINE>
+<LINE>Those that Hobgoblin call you and sweet Puck,</LINE>
+<LINE>You do their work, and they shall have good luck:</LINE>
+<LINE>Are not you he?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Thou speak'st aright;</LINE>
+<LINE>I am that merry wanderer of the night.</LINE>
+<LINE>I jest to Oberon and make him smile</LINE>
+<LINE>When I a fat and bean-fed horse beguile,</LINE>
+<LINE>Neighing in likeness of a filly foal:</LINE>
+<LINE>And sometime lurk I in a gossip's bowl,</LINE>
+<LINE>In very likeness of a roasted crab,</LINE>
+<LINE>And when she drinks, against her lips I bob</LINE>
+<LINE>And on her wither'd dewlap pour the ale.</LINE>
+<LINE>The wisest aunt, telling the saddest tale,</LINE>
+<LINE>Sometime for three-foot stool mistaketh me;</LINE>
+<LINE>Then slip I from her bum, down topples she,</LINE>
+<LINE>And 'tailor' cries, and falls into a cough;</LINE>
+<LINE>And then the whole quire hold their hips and laugh,</LINE>
+<LINE>And waxen in their mirth and neeze and swear</LINE>
+<LINE>A merrier hour was never wasted there.</LINE>
+<LINE>But, room, fairy! here comes Oberon.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Fairy</SPEAKER>
+<LINE>And here my mistress. Would that he were gone!</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter, from one side, OBERON, with his train;
+from the other, TITANIA, with hers</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Ill met by moonlight, proud Titania.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>What, jealous Oberon! Fairies, skip hence:</LINE>
+<LINE>I have forsworn his bed and company.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Tarry, rash wanton: am not I thy lord?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Then I must be thy lady: but I know</LINE>
+<LINE>When thou hast stolen away from fairy land,</LINE>
+<LINE>And in the shape of Corin sat all day,</LINE>
+<LINE>Playing on pipes of corn and versing love</LINE>
+<LINE>To amorous Phillida. Why art thou here,</LINE>
+<LINE>Come from the farthest Steppe of India?</LINE>
+<LINE>But that, forsooth, the bouncing Amazon,</LINE>
+<LINE>Your buskin'd mistress and your warrior love,</LINE>
+<LINE>To Theseus must be wedded, and you come</LINE>
+<LINE>To give their bed joy and prosperity.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>How canst thou thus for shame, Titania,</LINE>
+<LINE>Glance at my credit with Hippolyta,</LINE>
+<LINE>Knowing I know thy love to Theseus?</LINE>
+<LINE>Didst thou not lead him through the glimmering night</LINE>
+<LINE>From Perigenia, whom he ravished?</LINE>
+<LINE>And make him with fair AEgle break his faith,</LINE>
+<LINE>With Ariadne and Antiopa?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>These are the forgeries of jealousy:</LINE>
+<LINE>And never, since the middle summer's spring,</LINE>
+<LINE>Met we on hill, in dale, forest or mead,</LINE>
+<LINE>By paved fountain or by rushy brook,</LINE>
+<LINE>Or in the beached margent of the sea,</LINE>
+<LINE>To dance our ringlets to the whistling wind,</LINE>
+<LINE>But with thy brawls thou hast disturb'd our sport.</LINE>
+<LINE>Therefore the winds, piping to us in vain,</LINE>
+<LINE>As in revenge, have suck'd up from the sea</LINE>
+<LINE>Contagious fogs; which falling in the land</LINE>
+<LINE>Have every pelting river made so proud</LINE>
+<LINE>That they have overborne their continents:</LINE>
+<LINE>The ox hath therefore stretch'd his yoke in vain,</LINE>
+<LINE>The ploughman lost his sweat, and the green corn</LINE>
+<LINE>Hath rotted ere his youth attain'd a beard;</LINE>
+<LINE>The fold stands empty in the drowned field,</LINE>
+<LINE>And crows are fatted with the murrion flock;</LINE>
+<LINE>The nine men's morris is fill'd up with mud,</LINE>
+<LINE>And the quaint mazes in the wanton green</LINE>
+<LINE>For lack of tread are undistinguishable:</LINE>
+<LINE>The human mortals want their winter here;</LINE>
+<LINE>No night is now with hymn or carol blest:</LINE>
+<LINE>Therefore the moon, the governess of floods,</LINE>
+<LINE>Pale in her anger, washes all the air,</LINE>
+<LINE>That rheumatic diseases do abound:</LINE>
+<LINE>And thorough this distemperature we see</LINE>
+<LINE>The seasons alter: hoary-headed frosts</LINE>
+<LINE>Far in the fresh lap of the crimson rose,</LINE>
+<LINE>And on old Hiems' thin and icy crown</LINE>
+<LINE>An odorous chaplet of sweet summer buds</LINE>
+<LINE>Is, as in mockery, set: the spring, the summer,</LINE>
+<LINE>The childing autumn, angry winter, change</LINE>
+<LINE>Their wonted liveries, and the mazed world,</LINE>
+<LINE>By their increase, now knows not which is which:</LINE>
+<LINE>And this same progeny of evils comes</LINE>
+<LINE>From our debate, from our dissension;</LINE>
+<LINE>We are their parents and original.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Do you amend it then; it lies in you:</LINE>
+<LINE>Why should Titania cross her Oberon?</LINE>
+<LINE>I do but beg a little changeling boy,</LINE>
+<LINE>To be my henchman.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Set your heart at rest:</LINE>
+<LINE>The fairy land buys not the child of me.</LINE>
+<LINE>His mother was a votaress of my order:</LINE>
+<LINE>And, in the spiced Indian air, by night,</LINE>
+<LINE>Full often hath she gossip'd by my side,</LINE>
+<LINE>And sat with me on Neptune's yellow sands,</LINE>
+<LINE>Marking the embarked traders on the flood,</LINE>
+<LINE>When we have laugh'd to see the sails conceive</LINE>
+<LINE>And grow big-bellied with the wanton wind;</LINE>
+<LINE>Which she, with pretty and with swimming gait</LINE>
+<LINE>Following,--her womb then rich with my young squire,--</LINE>
+<LINE>Would imitate, and sail upon the land,</LINE>
+<LINE>To fetch me trifles, and return again,</LINE>
+<LINE>As from a voyage, rich with merchandise.</LINE>
+<LINE>But she, being mortal, of that boy did die;</LINE>
+<LINE>And for her sake do I rear up her boy,</LINE>
+<LINE>And for her sake I will not part with him.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>How long within this wood intend you stay?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Perchance till after Theseus' wedding-day.</LINE>
+<LINE>If you will patiently dance in our round</LINE>
+<LINE>And see our moonlight revels, go with us;</LINE>
+<LINE>If not, shun me, and I will spare your haunts.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Give me that boy, and I will go with thee.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Not for thy fairy kingdom. Fairies, away!</LINE>
+<LINE>We shall chide downright, if I longer stay.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit TITANIA with her train</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Well, go thy way: thou shalt not from this grove</LINE>
+<LINE>Till I torment thee for this injury.</LINE>
+<LINE>My gentle Puck, come hither. Thou rememberest</LINE>
+<LINE>Since once I sat upon a promontory,</LINE>
+<LINE>And heard a mermaid on a dolphin's back</LINE>
+<LINE>Uttering such dulcet and harmonious breath</LINE>
+<LINE>That the rude sea grew civil at her song</LINE>
+<LINE>And certain stars shot madly from their spheres,</LINE>
+<LINE>To hear the sea-maid's music.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>I remember.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>That very time I saw, but thou couldst not,</LINE>
+<LINE>Flying between the cold moon and the earth,</LINE>
+<LINE>Cupid all arm'd: a certain aim he took</LINE>
+<LINE>At a fair vestal throned by the west,</LINE>
+<LINE>And loosed his love-shaft smartly from his bow,</LINE>
+<LINE>As it should pierce a hundred thousand hearts;</LINE>
+<LINE>But I might see young Cupid's fiery shaft</LINE>
+<LINE>Quench'd in the chaste beams of the watery moon,</LINE>
+<LINE>And the imperial votaress passed on,</LINE>
+<LINE>In maiden meditation, fancy-free.</LINE>
+<LINE>Yet mark'd I where the bolt of Cupid fell:</LINE>
+<LINE>It fell upon a little western flower,</LINE>
+<LINE>Before milk-white, now purple with love's wound,</LINE>
+<LINE>And maidens call it love-in-idleness.</LINE>
+<LINE>Fetch me that flower; the herb I shew'd thee once:</LINE>
+<LINE>The juice of it on sleeping eye-lids laid</LINE>
+<LINE>Will make or man or woman madly dote</LINE>
+<LINE>Upon the next live creature that it sees.</LINE>
+<LINE>Fetch me this herb; and be thou here again</LINE>
+<LINE>Ere the leviathan can swim a league.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>I'll put a girdle round about the earth</LINE>
+<LINE>In forty minutes.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Having once this juice,</LINE>
+<LINE>I'll watch Titania when she is asleep,</LINE>
+<LINE>And drop the liquor of it in her eyes.</LINE>
+<LINE>The next thing then she waking looks upon,</LINE>
+<LINE>Be it on lion, bear, or wolf, or bull,</LINE>
+<LINE>On meddling monkey, or on busy ape,</LINE>
+<LINE>She shall pursue it with the soul of love:</LINE>
+<LINE>And ere I take this charm from off her sight,</LINE>
+<LINE>As I can take it with another herb,</LINE>
+<LINE>I'll make her render up her page to me.</LINE>
+<LINE>But who comes here? I am invisible;</LINE>
+<LINE>And I will overhear their conference.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter DEMETRIUS, HELENA, following him</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>I love thee not, therefore pursue me not.</LINE>
+<LINE>Where is Lysander and fair Hermia?</LINE>
+<LINE>The one I'll slay, the other slayeth me.</LINE>
+<LINE>Thou told'st me they were stolen unto this wood;</LINE>
+<LINE>And here am I, and wode within this wood,</LINE>
+<LINE>Because I cannot meet my Hermia.</LINE>
+<LINE>Hence, get thee gone, and follow me no more.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>You draw me, you hard-hearted adamant;</LINE>
+<LINE>But yet you draw not iron, for my heart</LINE>
+<LINE>Is true as steel: leave you your power to draw,</LINE>
+<LINE>And I shall have no power to follow you.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Do I entice you? do I speak you fair?</LINE>
+<LINE>Or, rather, do I not in plainest truth</LINE>
+<LINE>Tell you, I do not, nor I cannot love you?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>And even for that do I love you the more.</LINE>
+<LINE>I am your spaniel; and, Demetrius,</LINE>
+<LINE>The more you beat me, I will fawn on you:</LINE>
+<LINE>Use me but as your spaniel, spurn me, strike me,</LINE>
+<LINE>Neglect me, lose me; only give me leave,</LINE>
+<LINE>Unworthy as I am, to follow you.</LINE>
+<LINE>What worser place can I beg in your love,--</LINE>
+<LINE>And yet a place of high respect with me,--</LINE>
+<LINE>Than to be used as you use your dog?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Tempt not too much the hatred of my spirit;</LINE>
+<LINE>For I am sick when I do look on thee.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>And I am sick when I look not on you.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>You do impeach your modesty too much,</LINE>
+<LINE>To leave the city and commit yourself</LINE>
+<LINE>Into the hands of one that loves you not;</LINE>
+<LINE>To trust the opportunity of night</LINE>
+<LINE>And the ill counsel of a desert place</LINE>
+<LINE>With the rich worth of your virginity.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Your virtue is my privilege: for that</LINE>
+<LINE>It is not night when I do see your face,</LINE>
+<LINE>Therefore I think I am not in the night;</LINE>
+<LINE>Nor doth this wood lack worlds of company,</LINE>
+<LINE>For you in my respect are all the world:</LINE>
+<LINE>Then how can it be said I am alone,</LINE>
+<LINE>When all the world is here to look on me?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>I'll run from thee and hide me in the brakes,</LINE>
+<LINE>And leave thee to the mercy of wild beasts.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>The wildest hath not such a heart as you.</LINE>
+<LINE>Run when you will, the story shall be changed:</LINE>
+<LINE>Apollo flies, and Daphne holds the chase;</LINE>
+<LINE>The dove pursues the griffin; the mild hind</LINE>
+<LINE>Makes speed to catch the tiger; bootless speed,</LINE>
+<LINE>When cowardice pursues and valour flies.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>I will not stay thy questions; let me go:</LINE>
+<LINE>Or, if thou follow me, do not believe</LINE>
+<LINE>But I shall do thee mischief in the wood.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Ay, in the temple, in the town, the field,</LINE>
+<LINE>You do me mischief. Fie, Demetrius!</LINE>
+<LINE>Your wrongs do set a scandal on my sex:</LINE>
+<LINE>We cannot fight for love, as men may do;</LINE>
+<LINE>We should be wood and were not made to woo.</LINE>
+<STAGEDIR>Exit DEMETRIUS</STAGEDIR>
+<LINE>I'll follow thee and make a heaven of hell,</LINE>
+<LINE>To die upon the hand I love so well.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Fare thee well, nymph: ere he do leave this grove,</LINE>
+<LINE>Thou shalt fly him and he shall seek thy love.</LINE>
+<STAGEDIR>Re-enter PUCK</STAGEDIR>
+<LINE>Hast thou the flower there? Welcome, wanderer.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Ay, there it is.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>I pray thee, give it me.</LINE>
+<LINE>I know a bank where the wild thyme blows,</LINE>
+<LINE>Where oxlips and the nodding violet grows,</LINE>
+<LINE>Quite over-canopied with luscious woodbine,</LINE>
+<LINE>With sweet musk-roses and with eglantine:</LINE>
+<LINE>There sleeps Titania sometime of the night,</LINE>
+<LINE>Lull'd in these flowers with dances and delight;</LINE>
+<LINE>And there the snake throws her enamell'd skin,</LINE>
+<LINE>Weed wide enough to wrap a fairy in:</LINE>
+<LINE>And with the juice of this I'll streak her eyes,</LINE>
+<LINE>And make her full of hateful fantasies.</LINE>
+<LINE>Take thou some of it, and seek through this grove:</LINE>
+<LINE>A sweet Athenian lady is in love</LINE>
+<LINE>With a disdainful youth: anoint his eyes;</LINE>
+<LINE>But do it when the next thing he espies</LINE>
+<LINE>May be the lady: thou shalt know the man</LINE>
+<LINE>By the Athenian garments he hath on.</LINE>
+<LINE>Effect it with some care, that he may prove</LINE>
+<LINE>More fond on her than she upon her love:</LINE>
+<LINE>And look thou meet me ere the first cock crow.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Fear not, my lord, your servant shall do so.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt</STAGEDIR>
+</SCENE>
+
+<SCENE><TITLE>SCENE II.  Another part of the wood.</TITLE>
+<STAGEDIR>Enter TITANIA, with her train</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Come, now a roundel and a fairy song;</LINE>
+<LINE>Then, for the third part of a minute, hence;</LINE>
+<LINE>Some to kill cankers in the musk-rose buds,</LINE>
+<LINE>Some war with rere-mice for their leathern wings,</LINE>
+<LINE>To make my small elves coats, and some keep back</LINE>
+<LINE>The clamorous owl that nightly hoots and wonders</LINE>
+<LINE>At our quaint spirits. Sing me now asleep;</LINE>
+<LINE>Then to your offices and let me rest.</LINE>
+<STAGEDIR>The Fairies sing</STAGEDIR>
+<LINE>You spotted snakes with double tongue,</LINE>
+<LINE>Thorny hedgehogs, be not seen;</LINE>
+<LINE>Newts and blind-worms, do no wrong,</LINE>
+<LINE>Come not near our fairy queen.</LINE>
+<LINE>Philomel, with melody</LINE>
+<LINE>Sing in our sweet lullaby;</LINE>
+<LINE>Lulla, lulla, lullaby, lulla, lulla, lullaby:</LINE>
+<LINE>Never harm,</LINE>
+<LINE>Nor spell nor charm,</LINE>
+<LINE>Come our lovely lady nigh;</LINE>
+<LINE>So, good night, with lullaby.</LINE>
+<LINE>Weaving spiders, come not here;</LINE>
+<LINE>Hence, you long-legg'd spinners, hence!</LINE>
+<LINE>Beetles black, approach not near;</LINE>
+<LINE>Worm nor snail, do no offence.</LINE>
+<LINE>Philomel, with melody, &amp;c.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Fairy</SPEAKER>
+<LINE>Hence, away! now all is well:</LINE>
+<LINE>One aloof stand sentinel.</LINE>
+</SPEECH>
+
+<STAGEDIR>Exeunt Fairies. TITANIA sleeps</STAGEDIR>
+<STAGEDIR>Enter OBERON and squeezes the flower on TITANIA's eyelids</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>What thou seest when thou dost wake,</LINE>
+<LINE>Do it for thy true-love take,</LINE>
+<LINE>Love and languish for his sake:</LINE>
+<LINE>Be it ounce, or cat, or bear,</LINE>
+<LINE>Pard, or boar with bristled hair,</LINE>
+<LINE>In thy eye that shall appear</LINE>
+<LINE>When thou wakest, it is thy dear:</LINE>
+<LINE>Wake when some vile thing is near.</LINE>
+</SPEECH>
+
+<STAGEDIR>Exit</STAGEDIR>
+<STAGEDIR>Enter LYSANDER and HERMIA</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Fair love, you faint with wandering in the wood;</LINE>
+<LINE>And to speak troth, I have forgot our way:</LINE>
+<LINE>We'll rest us, Hermia, if you think it good,</LINE>
+<LINE>And tarry for the comfort of the day.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Be it so, Lysander: find you out a bed;</LINE>
+<LINE>For I upon this bank will rest my head.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>One turf shall serve as pillow for us both;</LINE>
+<LINE>One heart, one bed, two bosoms and one troth.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Nay, good Lysander; for my sake, my dear,</LINE>
+<LINE>Lie further off yet, do not lie so near.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>O, take the sense, sweet, of my innocence!</LINE>
+<LINE>Love takes the meaning in love's conference.</LINE>
+<LINE>I mean, that my heart unto yours is knit</LINE>
+<LINE>So that but one heart we can make of it;</LINE>
+<LINE>Two bosoms interchained with an oath;</LINE>
+<LINE>So then two bosoms and a single troth.</LINE>
+<LINE>Then by your side no bed-room me deny;</LINE>
+<LINE>For lying so, Hermia, I do not lie.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Lysander riddles very prettily:</LINE>
+<LINE>Now much beshrew my manners and my pride,</LINE>
+<LINE>If Hermia meant to say Lysander lied.</LINE>
+<LINE>But, gentle friend, for love and courtesy</LINE>
+<LINE>Lie further off; in human modesty,</LINE>
+<LINE>Such separation as may well be said</LINE>
+<LINE>Becomes a virtuous bachelor and a maid,</LINE>
+<LINE>So far be distant; and, good night, sweet friend:</LINE>
+<LINE>Thy love ne'er alter till thy sweet life end!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Amen, amen, to that fair prayer, say I;</LINE>
+<LINE>And then end life when I end loyalty!</LINE>
+<LINE>Here is my bed: sleep give thee all his rest!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>With half that wish the wisher's eyes be press'd!</LINE>
+</SPEECH>
+
+<STAGEDIR>They sleep</STAGEDIR>
+<STAGEDIR>Enter PUCK</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Through the forest have I gone.</LINE>
+<LINE>But Athenian found I none,</LINE>
+<LINE>On whose eyes I might approve</LINE>
+<LINE>This flower's force in stirring love.</LINE>
+<LINE>Night and silence.--Who is here?</LINE>
+<LINE>Weeds of Athens he doth wear:</LINE>
+<LINE>This is he, my master said,</LINE>
+<LINE>Despised the Athenian maid;</LINE>
+<LINE>And here the maiden, sleeping sound,</LINE>
+<LINE>On the dank and dirty ground.</LINE>
+<LINE>Pretty soul! she durst not lie</LINE>
+<LINE>Near this lack-love, this kill-courtesy.</LINE>
+<LINE>Churl, upon thy eyes I throw</LINE>
+<LINE>All the power this charm doth owe.</LINE>
+<LINE>When thou wakest, let love forbid</LINE>
+<LINE>Sleep his seat on thy eyelid:</LINE>
+<LINE>So awake when I am gone;</LINE>
+<LINE>For I must now to Oberon.</LINE>
+</SPEECH>
+
+<STAGEDIR>Exit</STAGEDIR>
+<STAGEDIR>Enter DEMETRIUS and HELENA, running</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Stay, though thou kill me, sweet Demetrius.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>I charge thee, hence, and do not haunt me thus.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>O, wilt thou darkling leave me? do not so.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Stay, on thy peril: I alone will go.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>O, I am out of breath in this fond chase!</LINE>
+<LINE>The more my prayer, the lesser is my grace.</LINE>
+<LINE>Happy is Hermia, wheresoe'er she lies;</LINE>
+<LINE>For she hath blessed and attractive eyes.</LINE>
+<LINE>How came her eyes so bright? Not with salt tears:</LINE>
+<LINE>If so, my eyes are oftener wash'd than hers.</LINE>
+<LINE>No, no, I am as ugly as a bear;</LINE>
+<LINE>For beasts that meet me run away for fear:</LINE>
+<LINE>Therefore no marvel though Demetrius</LINE>
+<LINE>Do, as a monster fly my presence thus.</LINE>
+<LINE>What wicked and dissembling glass of mine</LINE>
+<LINE>Made me compare with Hermia's sphery eyne?</LINE>
+<LINE>But who is here? Lysander! on the ground!</LINE>
+<LINE>Dead? or asleep? I see no blood, no wound.</LINE>
+<LINE>Lysander if you live, good sir, awake.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE><STAGEDIR>Awaking</STAGEDIR>  And run through fire I will for thy sweet sake.</LINE>
+<LINE>Transparent Helena! Nature shows art,</LINE>
+<LINE>That through thy bosom makes me see thy heart.</LINE>
+<LINE>Where is Demetrius? O, how fit a word</LINE>
+<LINE>Is that vile name to perish on my sword!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Do not say so, Lysander; say not so</LINE>
+<LINE>What though he love your Hermia? Lord, what though?</LINE>
+<LINE>Yet Hermia still loves you: then be content.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Content with Hermia! No; I do repent</LINE>
+<LINE>The tedious minutes I with her have spent.</LINE>
+<LINE>Not Hermia but Helena I love:</LINE>
+<LINE>Who will not change a raven for a dove?</LINE>
+<LINE>The will of man is by his reason sway'd;</LINE>
+<LINE>And reason says you are the worthier maid.</LINE>
+<LINE>Things growing are not ripe until their season</LINE>
+<LINE>So I, being young, till now ripe not to reason;</LINE>
+<LINE>And touching now the point of human skill,</LINE>
+<LINE>Reason becomes the marshal to my will</LINE>
+<LINE>And leads me to your eyes, where I o'erlook</LINE>
+<LINE>Love's stories written in love's richest book.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Wherefore was I to this keen mockery born?</LINE>
+<LINE>When at your hands did I deserve this scorn?</LINE>
+<LINE>Is't not enough, is't not enough, young man,</LINE>
+<LINE>That I did never, no, nor never can,</LINE>
+<LINE>Deserve a sweet look from Demetrius' eye,</LINE>
+<LINE>But you must flout my insufficiency?</LINE>
+<LINE>Good troth, you do me wrong, good sooth, you do,</LINE>
+<LINE>In such disdainful manner me to woo.</LINE>
+<LINE>But fare you well: perforce I must confess</LINE>
+<LINE>I thought you lord of more true gentleness.</LINE>
+<LINE>O, that a lady, of one man refused.</LINE>
+<LINE>Should of another therefore be abused!</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>She sees not Hermia. Hermia, sleep thou there:</LINE>
+<LINE>And never mayst thou come Lysander near!</LINE>
+<LINE>For as a surfeit of the sweetest things</LINE>
+<LINE>The deepest loathing to the stomach brings,</LINE>
+<LINE>Or as tie heresies that men do leave</LINE>
+<LINE>Are hated most of those they did deceive,</LINE>
+<LINE>So thou, my surfeit and my heresy,</LINE>
+<LINE>Of all be hated, but the most of me!</LINE>
+<LINE>And, all my powers, address your love and might</LINE>
+<LINE>To honour Helen and to be her knight!</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE><STAGEDIR>Awaking</STAGEDIR>  Help me, Lysander, help me! do thy best</LINE>
+<LINE>To pluck this crawling serpent from my breast!</LINE>
+<LINE>Ay me, for pity! what a dream was here!</LINE>
+<LINE>Lysander, look how I do quake with fear:</LINE>
+<LINE>Methought a serpent eat my heart away,</LINE>
+<LINE>And you sat smiling at his cruel pray.</LINE>
+<LINE>Lysander! what, removed? Lysander! lord!</LINE>
+<LINE>What, out of hearing? gone? no sound, no word?</LINE>
+<LINE>Alack, where are you speak, an if you hear;</LINE>
+<LINE>Speak, of all loves! I swoon almost with fear.</LINE>
+<LINE>No? then I well perceive you all not nigh</LINE>
+<LINE>Either death or you I'll find immediately.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+</SCENE>
+
+</ACT>
+
+<ACT><TITLE>ACT III</TITLE>
+
+<SCENE><TITLE>SCENE I.  The wood. TITANIA lying asleep.</TITLE>
+<STAGEDIR>Enter QUINCE, SNUG, BOTTOM, FLUTE, SNOUT, and
+STARVELING</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Are we all met?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Pat, pat; and here's a marvellous convenient place</LINE>
+<LINE>for our rehearsal. This green plot shall be our</LINE>
+<LINE>stage, this hawthorn-brake our tiring-house; and we</LINE>
+<LINE>will do it in action as we will do it before the duke.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Peter Quince,--</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>What sayest thou, bully Bottom?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>There are things in this comedy of Pyramus and</LINE>
+<LINE>Thisby that will never please. First, Pyramus must</LINE>
+<LINE>draw a sword to kill himself; which the ladies</LINE>
+<LINE>cannot abide. How answer you that?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>SNOUT</SPEAKER>
+<LINE>By'r lakin, a parlous fear.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>STARVELING</SPEAKER>
+<LINE>I believe we must leave the killing out, when all is done.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Not a whit: I have a device to make all well.</LINE>
+<LINE>Write me a prologue; and let the prologue seem to</LINE>
+<LINE>say, we will do no harm with our swords, and that</LINE>
+<LINE>Pyramus is not killed indeed; and, for the more</LINE>
+<LINE>better assurance, tell them that I, Pyramus, am not</LINE>
+<LINE>Pyramus, but Bottom the weaver: this will put them</LINE>
+<LINE>out of fear.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Well, we will have such a prologue; and it shall be</LINE>
+<LINE>written in eight and six.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>No, make it two more; let it be written in eight and eight.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>SNOUT</SPEAKER>
+<LINE>Will not the ladies be afeard of the lion?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>STARVELING</SPEAKER>
+<LINE>I fear it, I promise you.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Masters, you ought to consider with yourselves: to</LINE>
+<LINE>bring in--God shield us!--a lion among ladies, is a</LINE>
+<LINE>most dreadful thing; for there is not a more fearful</LINE>
+<LINE>wild-fowl than your lion living; and we ought to</LINE>
+<LINE>look to 't.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>SNOUT</SPEAKER>
+<LINE>Therefore another prologue must tell he is not a lion.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Nay, you must name his name, and half his face must</LINE>
+<LINE>be seen through the lion's neck: and he himself</LINE>
+<LINE>must speak through, saying thus, or to the same</LINE>
+<LINE>defect,--'Ladies,'--or 'Fair-ladies--I would wish</LINE>
+<LINE>You,'--or 'I would request you,'--or 'I would</LINE>
+<LINE>entreat you,--not to fear, not to tremble: my life</LINE>
+<LINE>for yours. If you think I come hither as a lion, it</LINE>
+<LINE>were pity of my life: no I am no such thing; I am a</LINE>
+<LINE>man as other men are;' and there indeed let him name</LINE>
+<LINE>his name, and tell them plainly he is Snug the joiner.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Well it shall be so. But there is two hard things;</LINE>
+<LINE>that is, to bring the moonlight into a chamber; for,</LINE>
+<LINE>you know, Pyramus and Thisby meet by moonlight.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>SNOUT</SPEAKER>
+<LINE>Doth the moon shine that night we play our play?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>A calendar, a calendar! look in the almanac; find</LINE>
+<LINE>out moonshine, find out moonshine.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Yes, it doth shine that night.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Why, then may you leave a casement of the great</LINE>
+<LINE>chamber window, where we play, open, and the moon</LINE>
+<LINE>may shine in at the casement.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Ay; or else one must come in with a bush of thorns</LINE>
+<LINE>and a lanthorn, and say he comes to disfigure, or to</LINE>
+<LINE>present, the person of Moonshine. Then, there is</LINE>
+<LINE>another thing: we must have a wall in the great</LINE>
+<LINE>chamber; for Pyramus and Thisby says the story, did</LINE>
+<LINE>talk through the chink of a wall.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>SNOUT</SPEAKER>
+<LINE>You can never bring in a wall. What say you, Bottom?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Some man or other must present Wall: and let him</LINE>
+<LINE>have some plaster, or some loam, or some rough-cast</LINE>
+<LINE>about him, to signify wall; and let him hold his</LINE>
+<LINE>fingers thus, and through that cranny shall Pyramus</LINE>
+<LINE>and Thisby whisper.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>If that may be, then all is well. Come, sit down,</LINE>
+<LINE>every mother's son, and rehearse your parts.</LINE>
+<LINE>Pyramus, you begin: when you have spoken your</LINE>
+<LINE>speech, enter into that brake: and so every one</LINE>
+<LINE>according to his cue.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter PUCK behind</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>What hempen home-spuns have we swaggering here,</LINE>
+<LINE>So near the cradle of the fairy queen?</LINE>
+<LINE>What, a play toward! I'll be an auditor;</LINE>
+<LINE>An actor too, perhaps, if I see cause.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Speak, Pyramus. Thisby, stand forth.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Thisby, the flowers of odious savours sweet,--</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Odours, odours.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>--odours savours sweet:</LINE>
+<LINE>So hath thy breath, my dearest Thisby dear.</LINE>
+<LINE>But hark, a voice! stay thou but here awhile,</LINE>
+<LINE>And by and by I will to thee appear.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>A stranger Pyramus than e'er played here.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>Must I speak now?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Ay, marry, must you; for you must understand he goes</LINE>
+<LINE>but to see a noise that he heard, and is to come again.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>Most radiant Pyramus, most lily-white of hue,</LINE>
+<LINE>Of colour like the red rose on triumphant brier,</LINE>
+<LINE>Most brisky juvenal and eke most lovely Jew,</LINE>
+<LINE>As true as truest horse that yet would never tire,</LINE>
+<LINE>I'll meet thee, Pyramus, at Ninny's tomb.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>'Ninus' tomb,' man: why, you must not speak that</LINE>
+<LINE>yet; that you answer to Pyramus: you speak all your</LINE>
+<LINE>part at once, cues and all Pyramus enter: your cue</LINE>
+<LINE>is past; it is, 'never tire.'</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>O,--As true as truest horse, that yet would</LINE>
+<LINE>never tire.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Re-enter PUCK, and BOTTOM with an ass's head</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>If I were fair, Thisby, I were only thine.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>O monstrous! O strange! we are haunted. Pray,</LINE>
+<LINE>masters! fly, masters! Help!</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt QUINCE, SNUG, FLUTE, SNOUT, and STARVELING</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>I'll follow you, I'll lead you about a round,</LINE>
+<LINE>Through bog, through bush, through brake, through brier:</LINE>
+<LINE>Sometime a horse I'll be, sometime a hound,</LINE>
+<LINE>A hog, a headless bear, sometime a fire;</LINE>
+<LINE>And neigh, and bark, and grunt, and roar, and burn,</LINE>
+<LINE>Like horse, hound, hog, bear, fire, at every turn.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Why do they run away? this is a knavery of them to</LINE>
+<LINE>make me afeard.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Re-enter SNOUT</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>SNOUT</SPEAKER>
+<LINE>O Bottom, thou art changed! what do I see on thee?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>What do you see? you see an asshead of your own, do</LINE>
+<LINE>you?</LINE>
+</SPEECH>
+
+<STAGEDIR>Exit SNOUT</STAGEDIR>
+<STAGEDIR>Re-enter QUINCE</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Bless thee, Bottom! bless thee! thou art</LINE>
+<LINE>translated.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>I see their knavery: this is to make an ass of me;</LINE>
+<LINE>to fright me, if they could. But I will not stir</LINE>
+<LINE>from this place, do what they can: I will walk up</LINE>
+<LINE>and down here, and I will sing, that they shall hear</LINE>
+<LINE>I am not afraid.</LINE>
+<STAGEDIR>Sings</STAGEDIR>
+<LINE>The ousel cock so black of hue,</LINE>
+<LINE>With orange-tawny bill,</LINE>
+<LINE>The throstle with his note so true,</LINE>
+<LINE>The wren with little quill,--</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE><STAGEDIR>Awaking</STAGEDIR>  What angel wakes me from my flowery bed?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE><STAGEDIR>Sings</STAGEDIR></LINE>
+<LINE>The finch, the sparrow and the lark,</LINE>
+<LINE>The plain-song cuckoo gray,</LINE>
+<LINE>Whose note full many a man doth mark,</LINE>
+<LINE>And dares not answer nay;--</LINE>
+<LINE>for, indeed, who would set his wit to so foolish</LINE>
+<LINE>a bird? who would give a bird the lie, though he cry</LINE>
+<LINE>'cuckoo' never so?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>I pray thee, gentle mortal, sing again:</LINE>
+<LINE>Mine ear is much enamour'd of thy note;</LINE>
+<LINE>So is mine eye enthralled to thy shape;</LINE>
+<LINE>And thy fair virtue's force perforce doth move me</LINE>
+<LINE>On the first view to say, to swear, I love thee.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Methinks, mistress, you should have little reason</LINE>
+<LINE>for that: and yet, to say the truth, reason and</LINE>
+<LINE>love keep little company together now-a-days; the</LINE>
+<LINE>more the pity that some honest neighbours will not</LINE>
+<LINE>make them friends. Nay, I can gleek upon occasion.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Thou art as wise as thou art beautiful.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Not so, neither: but if I had wit enough to get out</LINE>
+<LINE>of this wood, I have enough to serve mine own turn.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Out of this wood do not desire to go:</LINE>
+<LINE>Thou shalt remain here, whether thou wilt or no.</LINE>
+<LINE>I am a spirit of no common rate;</LINE>
+<LINE>The summer still doth tend upon my state;</LINE>
+<LINE>And I do love thee: therefore, go with me;</LINE>
+<LINE>I'll give thee fairies to attend on thee,</LINE>
+<LINE>And they shall fetch thee jewels from the deep,</LINE>
+<LINE>And sing while thou on pressed flowers dost sleep;</LINE>
+<LINE>And I will purge thy mortal grossness so</LINE>
+<LINE>That thou shalt like an airy spirit go.</LINE>
+<LINE>Peaseblossom! Cobweb! Moth! and Mustardseed!</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter PEASEBLOSSOM, COBWEB, MOTH, and MUSTARDSEED</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PEASEBLOSSOM</SPEAKER>
+<LINE>Ready.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>COBWEB</SPEAKER>
+<LINE>And I.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>MOTH</SPEAKER>
+<LINE>And I.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>MUSTARDSEED</SPEAKER>
+<LINE>And I.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>ALL</SPEAKER>
+<LINE>Where shall we go?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Be kind and courteous to this gentleman;</LINE>
+<LINE>Hop in his walks and gambol in his eyes;</LINE>
+<LINE>Feed him with apricocks and dewberries,</LINE>
+<LINE>With purple grapes, green figs, and mulberries;</LINE>
+<LINE>The honey-bags steal from the humble-bees,</LINE>
+<LINE>And for night-tapers crop their waxen thighs</LINE>
+<LINE>And light them at the fiery glow-worm's eyes,</LINE>
+<LINE>To have my love to bed and to arise;</LINE>
+<LINE>And pluck the wings from Painted butterflies</LINE>
+<LINE>To fan the moonbeams from his sleeping eyes:</LINE>
+<LINE>Nod to him, elves, and do him courtesies.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PEASEBLOSSOM</SPEAKER>
+<LINE>Hail, mortal!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>COBWEB</SPEAKER>
+<LINE>Hail!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>MOTH</SPEAKER>
+<LINE>Hail!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>MUSTARDSEED</SPEAKER>
+<LINE>Hail!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>I cry your worship's mercy, heartily: I beseech your</LINE>
+<LINE>worship's name.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>COBWEB</SPEAKER>
+<LINE>Cobweb.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>I shall desire you of more acquaintance, good Master</LINE>
+<LINE>Cobweb: if I cut my finger, I shall make bold with</LINE>
+<LINE>you. Your name, honest gentleman?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PEASEBLOSSOM</SPEAKER>
+<LINE>Peaseblossom.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>I pray you, commend me to Mistress Squash, your</LINE>
+<LINE>mother, and to Master Peascod, your father. Good</LINE>
+<LINE>Master Peaseblossom, I shall desire you of more</LINE>
+<LINE>acquaintance too. Your name, I beseech you, sir?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>MUSTARDSEED</SPEAKER>
+<LINE>Mustardseed.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Good Master Mustardseed, I know your patience well:</LINE>
+<LINE>that same cowardly, giant-like ox-beef hath</LINE>
+<LINE>devoured many a gentleman of your house: I promise</LINE>
+<LINE>you your kindred had made my eyes water ere now. I</LINE>
+<LINE>desire your more acquaintance, good Master</LINE>
+<LINE>Mustardseed.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Come, wait upon him; lead him to my bower.</LINE>
+<LINE>The moon methinks looks with a watery eye;</LINE>
+<LINE>And when she weeps, weeps every little flower,</LINE>
+<LINE>Lamenting some enforced chastity.</LINE>
+<LINE>Tie up my love's tongue bring him silently.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt</STAGEDIR>
+</SCENE>
+
+<SCENE><TITLE>SCENE II.  Another part of the wood.</TITLE>
+<STAGEDIR>Enter OBERON</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>I wonder if Titania be awaked;</LINE>
+<LINE>Then, what it was that next came in her eye,</LINE>
+<LINE>Which she must dote on in extremity.</LINE>
+<STAGEDIR>Enter PUCK</STAGEDIR>
+<LINE>Here comes my messenger.</LINE>
+<LINE>How now, mad spirit!</LINE>
+<LINE>What night-rule now about this haunted grove?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>My mistress with a monster is in love.</LINE>
+<LINE>Near to her close and consecrated bower,</LINE>
+<LINE>While she was in her dull and sleeping hour,</LINE>
+<LINE>A crew of patches, rude mechanicals,</LINE>
+<LINE>That work for bread upon Athenian stalls,</LINE>
+<LINE>Were met together to rehearse a play</LINE>
+<LINE>Intended for great Theseus' nuptial-day.</LINE>
+<LINE>The shallowest thick-skin of that barren sort,</LINE>
+<LINE>Who Pyramus presented, in their sport</LINE>
+<LINE>Forsook his scene and enter'd in a brake</LINE>
+<LINE>When I did him at this advantage take,</LINE>
+<LINE>An ass's nole I fixed on his head:</LINE>
+<LINE>Anon his Thisbe must be answered,</LINE>
+<LINE>And forth my mimic comes. When they him spy,</LINE>
+<LINE>As wild geese that the creeping fowler eye,</LINE>
+<LINE>Or russet-pated choughs, many in sort,</LINE>
+<LINE>Rising and cawing at the gun's report,</LINE>
+<LINE>Sever themselves and madly sweep the sky,</LINE>
+<LINE>So, at his sight, away his fellows fly;</LINE>
+<LINE>And, at our stamp, here o'er and o'er one falls;</LINE>
+<LINE>He murder cries and help from Athens calls.</LINE>
+<LINE>Their sense thus weak, lost with their fears</LINE>
+<LINE>thus strong,</LINE>
+<LINE>Made senseless things begin to do them wrong;</LINE>
+<LINE>For briers and thorns at their apparel snatch;</LINE>
+<LINE>Some sleeves, some hats, from yielders all</LINE>
+<LINE>things catch.</LINE>
+<LINE>I led them on in this distracted fear,</LINE>
+<LINE>And left sweet Pyramus translated there:</LINE>
+<LINE>When in that moment, so it came to pass,</LINE>
+<LINE>Titania waked and straightway loved an ass.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>This falls out better than I could devise.</LINE>
+<LINE>But hast thou yet latch'd the Athenian's eyes</LINE>
+<LINE>With the love-juice, as I did bid thee do?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>I took him sleeping,--that is finish'd too,--</LINE>
+<LINE>And the Athenian woman by his side:</LINE>
+<LINE>That, when he waked, of force she must be eyed.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter HERMIA and DEMETRIUS</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Stand close: this is the same Athenian.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>This is the woman, but not this the man.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>O, why rebuke you him that loves you so?</LINE>
+<LINE>Lay breath so bitter on your bitter foe.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Now I but chide; but I should use thee worse,</LINE>
+<LINE>For thou, I fear, hast given me cause to curse,</LINE>
+<LINE>If thou hast slain Lysander in his sleep,</LINE>
+<LINE>Being o'er shoes in blood, plunge in the deep,</LINE>
+<LINE>And kill me too.</LINE>
+<LINE>The sun was not so true unto the day</LINE>
+<LINE>As he to me: would he have stolen away</LINE>
+<LINE>From sleeping Hermia? I'll believe as soon</LINE>
+<LINE>This whole earth may be bored and that the moon</LINE>
+<LINE>May through the centre creep and so displease</LINE>
+<LINE>Her brother's noontide with Antipodes.</LINE>
+<LINE>It cannot be but thou hast murder'd him;</LINE>
+<LINE>So should a murderer look, so dead, so grim.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>So should the murder'd look, and so should I,</LINE>
+<LINE>Pierced through the heart with your stern cruelty:</LINE>
+<LINE>Yet you, the murderer, look as bright, as clear,</LINE>
+<LINE>As yonder Venus in her glimmering sphere.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>What's this to my Lysander? where is he?</LINE>
+<LINE>Ah, good Demetrius, wilt thou give him me?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>I had rather give his carcass to my hounds.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Out, dog! out, cur! thou drivest me past the bounds</LINE>
+<LINE>Of maiden's patience. Hast thou slain him, then?</LINE>
+<LINE>Henceforth be never number'd among men!</LINE>
+<LINE>O, once tell true, tell true, even for my sake!</LINE>
+<LINE>Durst thou have look'd upon him being awake,</LINE>
+<LINE>And hast thou kill'd him sleeping? O brave touch!</LINE>
+<LINE>Could not a worm, an adder, do so much?</LINE>
+<LINE>An adder did it; for with doubler tongue</LINE>
+<LINE>Than thine, thou serpent, never adder stung.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>You spend your passion on a misprised mood:</LINE>
+<LINE>I am not guilty of Lysander's blood;</LINE>
+<LINE>Nor is he dead, for aught that I can tell.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>I pray thee, tell me then that he is well.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>An if I could, what should I get therefore?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>A privilege never to see me more.</LINE>
+<LINE>And from thy hated presence part I so:</LINE>
+<LINE>See me no more, whether he be dead or no.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>There is no following her in this fierce vein:</LINE>
+<LINE>Here therefore for a while I will remain.</LINE>
+<LINE>So sorrow's heaviness doth heavier grow</LINE>
+<LINE>For debt that bankrupt sleep doth sorrow owe:</LINE>
+<LINE>Which now in some slight measure it will pay,</LINE>
+<LINE>If for his tender here I make some stay.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Lies down and sleeps</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>What hast thou done? thou hast mistaken quite</LINE>
+<LINE>And laid the love-juice on some true-love's sight:</LINE>
+<LINE>Of thy misprision must perforce ensue</LINE>
+<LINE>Some true love turn'd and not a false turn'd true.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Then fate o'er-rules, that, one man holding troth,</LINE>
+<LINE>A million fail, confounding oath on oath.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>About the wood go swifter than the wind,</LINE>
+<LINE>And Helena of Athens look thou find:</LINE>
+<LINE>All fancy-sick she is and pale of cheer,</LINE>
+<LINE>With sighs of love, that costs the fresh blood dear:</LINE>
+<LINE>By some illusion see thou bring her here:</LINE>
+<LINE>I'll charm his eyes against she do appear.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>I go, I go; look how I go,</LINE>
+<LINE>Swifter than arrow from the Tartar's bow.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Flower of this purple dye,</LINE>
+<LINE>Hit with Cupid's archery,</LINE>
+<LINE>Sink in apple of his eye.</LINE>
+<LINE>When his love he doth espy,</LINE>
+<LINE>Let her shine as gloriously</LINE>
+<LINE>As the Venus of the sky.</LINE>
+<LINE>When thou wakest, if she be by,</LINE>
+<LINE>Beg of her for remedy.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Re-enter PUCK</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Captain of our fairy band,</LINE>
+<LINE>Helena is here at hand;</LINE>
+<LINE>And the youth, mistook by me,</LINE>
+<LINE>Pleading for a lover's fee.</LINE>
+<LINE>Shall we their fond pageant see?</LINE>
+<LINE>Lord, what fools these mortals be!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Stand aside: the noise they make</LINE>
+<LINE>Will cause Demetrius to awake.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Then will two at once woo one;</LINE>
+<LINE>That must needs be sport alone;</LINE>
+<LINE>And those things do best please me</LINE>
+<LINE>That befal preposterously.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter LYSANDER and HELENA</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Why should you think that I should woo in scorn?</LINE>
+<LINE>Scorn and derision never come in tears:</LINE>
+<LINE>Look, when I vow, I weep; and vows so born,</LINE>
+<LINE>In their nativity all truth appears.</LINE>
+<LINE>How can these things in me seem scorn to you,</LINE>
+<LINE>Bearing the badge of faith, to prove them true?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>You do advance your cunning more and more.</LINE>
+<LINE>When truth kills truth, O devilish-holy fray!</LINE>
+<LINE>These vows are Hermia's: will you give her o'er?</LINE>
+<LINE>Weigh oath with oath, and you will nothing weigh:</LINE>
+<LINE>Your vows to her and me, put in two scales,</LINE>
+<LINE>Will even weigh, and both as light as tales.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>I had no judgment when to her I swore.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Nor none, in my mind, now you give her o'er.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Demetrius loves her, and he loves not you.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE><STAGEDIR>Awaking</STAGEDIR>  O Helena, goddess, nymph, perfect, divine!</LINE>
+<LINE>To what, my love, shall I compare thine eyne?</LINE>
+<LINE>Crystal is muddy. O, how ripe in show</LINE>
+<LINE>Thy lips, those kissing cherries, tempting grow!</LINE>
+<LINE>That pure congealed white, high Taurus snow,</LINE>
+<LINE>Fann'd with the eastern wind, turns to a crow</LINE>
+<LINE>When thou hold'st up thy hand: O, let me kiss</LINE>
+<LINE>This princess of pure white, this seal of bliss!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>O spite! O hell! I see you all are bent</LINE>
+<LINE>To set against me for your merriment:</LINE>
+<LINE>If you we re civil and knew courtesy,</LINE>
+<LINE>You would not do me thus much injury.</LINE>
+<LINE>Can you not hate me, as I know you do,</LINE>
+<LINE>But you must join in souls to mock me too?</LINE>
+<LINE>If you were men, as men you are in show,</LINE>
+<LINE>You would not use a gentle lady so;</LINE>
+<LINE>To vow, and swear, and superpraise my parts,</LINE>
+<LINE>When I am sure you hate me with your hearts.</LINE>
+<LINE>You both are rivals, and love Hermia;</LINE>
+<LINE>And now both rivals, to mock Helena:</LINE>
+<LINE>A trim exploit, a manly enterprise,</LINE>
+<LINE>To conjure tears up in a poor maid's eyes</LINE>
+<LINE>With your derision! none of noble sort</LINE>
+<LINE>Would so offend a virgin, and extort</LINE>
+<LINE>A poor soul's patience, all to make you sport.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>You are unkind, Demetrius; be not so;</LINE>
+<LINE>For you love Hermia; this you know I know:</LINE>
+<LINE>And here, with all good will, with all my heart,</LINE>
+<LINE>In Hermia's love I yield you up my part;</LINE>
+<LINE>And yours of Helena to me bequeath,</LINE>
+<LINE>Whom I do love and will do till my death.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Never did mockers waste more idle breath.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Lysander, keep thy Hermia; I will none:</LINE>
+<LINE>If e'er I loved her, all that love is gone.</LINE>
+<LINE>My heart to her but as guest-wise sojourn'd,</LINE>
+<LINE>And now to Helen is it home return'd,</LINE>
+<LINE>There to remain.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Helen, it is not so.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Disparage not the faith thou dost not know,</LINE>
+<LINE>Lest, to thy peril, thou aby it dear.</LINE>
+<LINE>Look, where thy love comes; yonder is thy dear.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Re-enter HERMIA</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Dark night, that from the eye his function takes,</LINE>
+<LINE>The ear more quick of apprehension makes;</LINE>
+<LINE>Wherein it doth impair the seeing sense,</LINE>
+<LINE>It pays the hearing double recompense.</LINE>
+<LINE>Thou art not by mine eye, Lysander, found;</LINE>
+<LINE>Mine ear, I thank it, brought me to thy sound</LINE>
+<LINE>But why unkindly didst thou leave me so?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Why should he stay, whom love doth press to go?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>What love could press Lysander from my side?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Lysander's love, that would not let him bide,</LINE>
+<LINE>Fair Helena, who more engilds the night</LINE>
+<LINE>Than all you fiery oes and eyes of light.</LINE>
+<LINE>Why seek'st thou me? could not this make thee know,</LINE>
+<LINE>The hate I bear thee made me leave thee so?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>You speak not as you think: it cannot be.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Lo, she is one of this confederacy!</LINE>
+<LINE>Now I perceive they have conjoin'd all three</LINE>
+<LINE>To fashion this false sport, in spite of me.</LINE>
+<LINE>Injurious Hermia! most ungrateful maid!</LINE>
+<LINE>Have you conspired, have you with these contrived</LINE>
+<LINE>To bait me with this foul derision?</LINE>
+<LINE>Is all the counsel that we two have shared,</LINE>
+<LINE>The sisters' vows, the hours that we have spent,</LINE>
+<LINE>When we have chid the hasty-footed time</LINE>
+<LINE>For parting us,--O, is it all forgot?</LINE>
+<LINE>All school-days' friendship, childhood innocence?</LINE>
+<LINE>We, Hermia, like two artificial gods,</LINE>
+<LINE>Have with our needles created both one flower,</LINE>
+<LINE>Both on one sampler, sitting on one cushion,</LINE>
+<LINE>Both warbling of one song, both in one key,</LINE>
+<LINE>As if our hands, our sides, voices and minds,</LINE>
+<LINE>Had been incorporate. So we grow together,</LINE>
+<LINE>Like to a double cherry, seeming parted,</LINE>
+<LINE>But yet an union in partition;</LINE>
+<LINE>Two lovely berries moulded on one stem;</LINE>
+<LINE>So, with two seeming bodies, but one heart;</LINE>
+<LINE>Two of the first, like coats in heraldry,</LINE>
+<LINE>Due but to one and crowned with one crest.</LINE>
+<LINE>And will you rent our ancient love asunder,</LINE>
+<LINE>To join with men in scorning your poor friend?</LINE>
+<LINE>It is not friendly, 'tis not maidenly:</LINE>
+<LINE>Our sex, as well as I, may chide you for it,</LINE>
+<LINE>Though I alone do feel the injury.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>I am amazed at your passionate words.</LINE>
+<LINE>I scorn you not: it seems that you scorn me.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Have you not set Lysander, as in scorn,</LINE>
+<LINE>To follow me and praise my eyes and face?</LINE>
+<LINE>And made your other love, Demetrius,</LINE>
+<LINE>Who even but now did spurn me with his foot,</LINE>
+<LINE>To call me goddess, nymph, divine and rare,</LINE>
+<LINE>Precious, celestial? Wherefore speaks he this</LINE>
+<LINE>To her he hates? and wherefore doth Lysander</LINE>
+<LINE>Deny your love, so rich within his soul,</LINE>
+<LINE>And tender me, forsooth, affection,</LINE>
+<LINE>But by your setting on, by your consent?</LINE>
+<LINE>What thought I be not so in grace as you,</LINE>
+<LINE>So hung upon with love, so fortunate,</LINE>
+<LINE>But miserable most, to love unloved?</LINE>
+<LINE>This you should pity rather than despise.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERNIA</SPEAKER>
+<LINE>I understand not what you mean by this.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Ay, do, persever, counterfeit sad looks,</LINE>
+<LINE>Make mouths upon me when I turn my back;</LINE>
+<LINE>Wink each at other; hold the sweet jest up:</LINE>
+<LINE>This sport, well carried, shall be chronicled.</LINE>
+<LINE>If you have any pity, grace, or manners,</LINE>
+<LINE>You would not make me such an argument.</LINE>
+<LINE>But fare ye well: 'tis partly my own fault;</LINE>
+<LINE>Which death or absence soon shall remedy.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Stay, gentle Helena; hear my excuse:</LINE>
+<LINE>My love, my life my soul, fair Helena!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>O excellent!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Sweet, do not scorn her so.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>If she cannot entreat, I can compel.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Thou canst compel no more than she entreat:</LINE>
+<LINE>Thy threats have no more strength than her weak prayers.</LINE>
+<LINE>Helen, I love thee; by my life, I do:</LINE>
+<LINE>I swear by that which I will lose for thee,</LINE>
+<LINE>To prove him false that says I love thee not.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>I say I love thee more than he can do.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>If thou say so, withdraw, and prove it too.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Quick, come!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Lysander, whereto tends all this?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Away, you Ethiope!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>No, no; he'll</LINE>
+<LINE>Seem to break loose; take on as you would follow,</LINE>
+<LINE>But yet come not: you are a tame man, go!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Hang off, thou cat, thou burr! vile thing, let loose,</LINE>
+<LINE>Or I will shake thee from me like a serpent!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Why are you grown so rude? what change is this?</LINE>
+<LINE>Sweet love,--</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Thy love! out, tawny Tartar, out!</LINE>
+<LINE>Out, loathed medicine! hated potion, hence!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Do you not jest?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Yes, sooth; and so do you.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Demetrius, I will keep my word with thee.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>I would I had your bond, for I perceive</LINE>
+<LINE>A weak bond holds you: I'll not trust your word.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>What, should I hurt her, strike her, kill her dead?</LINE>
+<LINE>Although I hate her, I'll not harm her so.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>What, can you do me greater harm than hate?</LINE>
+<LINE>Hate me! wherefore? O me! what news, my love!</LINE>
+<LINE>Am not I Hermia? are not you Lysander?</LINE>
+<LINE>I am as fair now as I was erewhile.</LINE>
+<LINE>Since night you loved me; yet since night you left</LINE>
+<LINE>me:</LINE>
+<LINE>Why, then you left me--O, the gods forbid!--</LINE>
+<LINE>In earnest, shall I say?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Ay, by my life;</LINE>
+<LINE>And never did desire to see thee more.</LINE>
+<LINE>Therefore be out of hope, of question, of doubt;</LINE>
+<LINE>Be certain, nothing truer; 'tis no jest</LINE>
+<LINE>That I do hate thee and love Helena.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>O me! you juggler! you canker-blossom!</LINE>
+<LINE>You thief of love! what, have you come by night</LINE>
+<LINE>And stolen my love's heart from him?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Fine, i'faith!</LINE>
+<LINE>Have you no modesty, no maiden shame,</LINE>
+<LINE>No touch of bashfulness? What, will you tear</LINE>
+<LINE>Impatient answers from my gentle tongue?</LINE>
+<LINE>Fie, fie! you counterfeit, you puppet, you!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Puppet? why so? ay, that way goes the game.</LINE>
+<LINE>Now I perceive that she hath made compare</LINE>
+<LINE>Between our statures; she hath urged her height;</LINE>
+<LINE>And with her personage, her tall personage,</LINE>
+<LINE>Her height, forsooth, she hath prevail'd with him.</LINE>
+<LINE>And are you grown so high in his esteem;</LINE>
+<LINE>Because I am so dwarfish and so low?</LINE>
+<LINE>How low am I, thou painted maypole? speak;</LINE>
+<LINE>How low am I? I am not yet so low</LINE>
+<LINE>But that my nails can reach unto thine eyes.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>I pray you, though you mock me, gentlemen,</LINE>
+<LINE>Let her not hurt me: I was never curst;</LINE>
+<LINE>I have no gift at all in shrewishness;</LINE>
+<LINE>I am a right maid for my cowardice:</LINE>
+<LINE>Let her not strike me. You perhaps may think,</LINE>
+<LINE>Because she is something lower than myself,</LINE>
+<LINE>That I can match her.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Lower! hark, again.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>Good Hermia, do not be so bitter with me.</LINE>
+<LINE>I evermore did love you, Hermia,</LINE>
+<LINE>Did ever keep your counsels, never wrong'd you;</LINE>
+<LINE>Save that, in love unto Demetrius,</LINE>
+<LINE>I told him of your stealth unto this wood.</LINE>
+<LINE>He follow'd you; for love I follow'd him;</LINE>
+<LINE>But he hath chid me hence and threaten'd me</LINE>
+<LINE>To strike me, spurn me, nay, to kill me too:</LINE>
+<LINE>And now, so you will let me quiet go,</LINE>
+<LINE>To Athens will I bear my folly back</LINE>
+<LINE>And follow you no further: let me go:</LINE>
+<LINE>You see how simple and how fond I am.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Why, get you gone: who is't that hinders you?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>A foolish heart, that I leave here behind.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>What, with Lysander?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>With Demetrius.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Be not afraid; she shall not harm thee, Helena.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>No, sir, she shall not, though you take her part.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>O, when she's angry, she is keen and shrewd!</LINE>
+<LINE>She was a vixen when she went to school;</LINE>
+<LINE>And though she be but little, she is fierce.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>'Little' again! nothing but 'low' and 'little'!</LINE>
+<LINE>Why will you suffer her to flout me thus?</LINE>
+<LINE>Let me come to her.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Get you gone, you dwarf;</LINE>
+<LINE>You minimus, of hindering knot-grass made;</LINE>
+<LINE>You bead, you acorn.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>You are too officious</LINE>
+<LINE>In her behalf that scorns your services.</LINE>
+<LINE>Let her alone: speak not of Helena;</LINE>
+<LINE>Take not her part; for, if thou dost intend</LINE>
+<LINE>Never so little show of love to her,</LINE>
+<LINE>Thou shalt aby it.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Now she holds me not;</LINE>
+<LINE>Now follow, if thou darest, to try whose right,</LINE>
+<LINE>Of thine or mine, is most in Helena.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Follow! nay, I'll go with thee, cheek by jole.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt LYSANDER and DEMETRIUS</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>You, mistress, all this coil is 'long of you:</LINE>
+<LINE>Nay, go not back.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>I will not trust you, I,</LINE>
+<LINE>Nor longer stay in your curst company.</LINE>
+<LINE>Your hands than mine are quicker for a fray,</LINE>
+<LINE>My legs are longer though, to run away.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>I am amazed, and know not what to say.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>This is thy negligence: still thou mistakest,</LINE>
+<LINE>Or else committ'st thy knaveries wilfully.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Believe me, king of shadows, I mistook.</LINE>
+<LINE>Did not you tell me I should know the man</LINE>
+<LINE>By the Athenian garment be had on?</LINE>
+<LINE>And so far blameless proves my enterprise,</LINE>
+<LINE>That I have 'nointed an Athenian's eyes;</LINE>
+<LINE>And so far am I glad it so did sort</LINE>
+<LINE>As this their jangling I esteem a sport.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Thou see'st these lovers seek a place to fight:</LINE>
+<LINE>Hie therefore, Robin, overcast the night;</LINE>
+<LINE>The starry welkin cover thou anon</LINE>
+<LINE>With drooping fog as black as Acheron,</LINE>
+<LINE>And lead these testy rivals so astray</LINE>
+<LINE>As one come not within another's way.</LINE>
+<LINE>Like to Lysander sometime frame thy tongue,</LINE>
+<LINE>Then stir Demetrius up with bitter wrong;</LINE>
+<LINE>And sometime rail thou like Demetrius;</LINE>
+<LINE>And from each other look thou lead them thus,</LINE>
+<LINE>Till o'er their brows death-counterfeiting sleep</LINE>
+<LINE>With leaden legs and batty wings doth creep:</LINE>
+<LINE>Then crush this herb into Lysander's eye;</LINE>
+<LINE>Whose liquor hath this virtuous property,</LINE>
+<LINE>To take from thence all error with his might,</LINE>
+<LINE>And make his eyeballs roll with wonted sight.</LINE>
+<LINE>When they next wake, all this derision</LINE>
+<LINE>Shall seem a dream and fruitless vision,</LINE>
+<LINE>And back to Athens shall the lovers wend,</LINE>
+<LINE>With league whose date till death shall never end.</LINE>
+<LINE>Whiles I in this affair do thee employ,</LINE>
+<LINE>I'll to my queen and beg her Indian boy;</LINE>
+<LINE>And then I will her charmed eye release</LINE>
+<LINE>From monster's view, and all things shall be peace.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>My fairy lord, this must be done with haste,</LINE>
+<LINE>For night's swift dragons cut the clouds full fast,</LINE>
+<LINE>And yonder shines Aurora's harbinger;</LINE>
+<LINE>At whose approach, ghosts, wandering here and there,</LINE>
+<LINE>Troop home to churchyards: damned spirits all,</LINE>
+<LINE>That in crossways and floods have burial,</LINE>
+<LINE>Already to their wormy beds are gone;</LINE>
+<LINE>For fear lest day should look their shames upon,</LINE>
+<LINE>They willfully themselves exile from light</LINE>
+<LINE>And must for aye consort with black-brow'd night.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>But we are spirits of another sort:</LINE>
+<LINE>I with the morning's love have oft made sport,</LINE>
+<LINE>And, like a forester, the groves may tread,</LINE>
+<LINE>Even till the eastern gate, all fiery-red,</LINE>
+<LINE>Opening on Neptune with fair blessed beams,</LINE>
+<LINE>Turns into yellow gold his salt green streams.</LINE>
+<LINE>But, notwithstanding, haste; make no delay:</LINE>
+<LINE>We may effect this business yet ere day.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Up and down, up and down,</LINE>
+<LINE>I will lead them up and down:</LINE>
+<LINE>I am fear'd in field and town:</LINE>
+<LINE>Goblin, lead them up and down.</LINE>
+<LINE>Here comes one.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Re-enter LYSANDER</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Where art thou, proud Demetrius? speak thou now.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Here, villain; drawn and ready. Where art thou?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>I will be with thee straight.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Follow me, then,</LINE>
+<LINE>To plainer ground.</LINE>
+</SPEECH>
+
+<STAGEDIR>Exit LYSANDER, as following the voice</STAGEDIR>
+<STAGEDIR>Re-enter DEMETRIUS</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Lysander! speak again:</LINE>
+<LINE>Thou runaway, thou coward, art thou fled?</LINE>
+<LINE>Speak! In some bush? Where dost thou hide thy head?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Thou coward, art thou bragging to the stars,</LINE>
+<LINE>Telling the bushes that thou look'st for wars,</LINE>
+<LINE>And wilt not come? Come, recreant; come, thou child;</LINE>
+<LINE>I'll whip thee with a rod: he is defiled</LINE>
+<LINE>That draws a sword on thee.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Yea, art thou there?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Follow my voice: we'll try no manhood here.</LINE>
+</SPEECH>
+
+<STAGEDIR>Exeunt</STAGEDIR>
+<STAGEDIR>Re-enter LYSANDER</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>He goes before me and still dares me on:</LINE>
+<LINE>When I come where he calls, then he is gone.</LINE>
+<LINE>The villain is much lighter-heel'd than I:</LINE>
+<LINE>I follow'd fast, but faster he did fly;</LINE>
+<LINE>That fallen am I in dark uneven way,</LINE>
+<LINE>And here will rest me.</LINE>
+<STAGEDIR>Lies down</STAGEDIR>
+<LINE>Come, thou gentle day!</LINE>
+<LINE>For if but once thou show me thy grey light,</LINE>
+<LINE>I'll find Demetrius and revenge this spite.</LINE>
+</SPEECH>
+
+<STAGEDIR>Sleeps</STAGEDIR>
+<STAGEDIR>Re-enter PUCK and DEMETRIUS</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Ho, ho, ho! Coward, why comest thou not?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Abide me, if thou darest; for well I wot</LINE>
+<LINE>Thou runn'st before me, shifting every place,</LINE>
+<LINE>And darest not stand, nor look me in the face.</LINE>
+<LINE>Where art thou now?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Come hither: I am here.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Nay, then, thou mock'st me. Thou shalt buy this dear,</LINE>
+<LINE>If ever I thy face by daylight see:</LINE>
+<LINE>Now, go thy way. Faintness constraineth me</LINE>
+<LINE>To measure out my length on this cold bed.</LINE>
+<LINE>By day's approach look to be visited.</LINE>
+</SPEECH>
+
+<STAGEDIR>Lies down and sleeps</STAGEDIR>
+<STAGEDIR>Re-enter HELENA</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>O weary night, O long and tedious night,</LINE>
+<LINE>Abate thy hour! Shine comforts from the east,</LINE>
+<LINE>That I may back to Athens by daylight,</LINE>
+<LINE>From these that my poor company detest:</LINE>
+<LINE>And sleep, that sometimes shuts up sorrow's eye,</LINE>
+<LINE>Steal me awhile from mine own company.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Lies down and sleeps</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Yet but three? Come one more;</LINE>
+<LINE>Two of both kinds make up four.</LINE>
+<LINE>Here she comes, curst and sad:</LINE>
+<LINE>Cupid is a knavish lad,</LINE>
+<LINE>Thus to make poor females mad.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Re-enter HERMIA</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Never so weary, never so in woe,</LINE>
+<LINE>Bedabbled with the dew and torn with briers,</LINE>
+<LINE>I can no further crawl, no further go;</LINE>
+<LINE>My legs can keep no pace with my desires.</LINE>
+<LINE>Here will I rest me till the break of day.</LINE>
+<LINE>Heavens shield Lysander, if they mean a fray!</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Lies down and sleeps</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>On the ground</LINE>
+<LINE>Sleep sound:</LINE>
+<LINE>I'll apply</LINE>
+<LINE>To your eye,</LINE>
+<LINE>Gentle lover, remedy.</LINE>
+<STAGEDIR>Squeezing the juice on LYSANDER's eyes</STAGEDIR>
+<LINE>When thou wakest,</LINE>
+<LINE>Thou takest</LINE>
+<LINE>True delight</LINE>
+<LINE>In the sight</LINE>
+<LINE>Of thy former lady's eye:</LINE>
+<LINE>And the country proverb known,</LINE>
+<LINE>That every man should take his own,</LINE>
+<LINE>In your waking shall be shown:</LINE>
+<LINE>Jack shall have Jill;</LINE>
+<LINE>Nought shall go ill;</LINE>
+<LINE>The man shall have his mare again, and all shall be well.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+</SCENE>
+
+</ACT>
+
+<ACT><TITLE>ACT IV</TITLE>
+
+<SCENE><TITLE>SCENE I.  The same. LYSANDER, DEMETRIUS, HELENA, and HERMIA lying asleep.</TITLE>
+<STAGEDIR>Enter TITANIA and BOTTOM; PEASEBLOSSOM, COBWEB, MOTH,
+MUSTARDSEED, and other Fairies attending; OBERON
+behind unseen</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Come, sit thee down upon this flowery bed,</LINE>
+<LINE>While I thy amiable cheeks do coy,</LINE>
+<LINE>And stick musk-roses in thy sleek smooth head,</LINE>
+<LINE>And kiss thy fair large ears, my gentle joy.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Where's Peaseblossom?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PEASEBLOSSOM</SPEAKER>
+<LINE>Ready.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Scratch my head Peaseblossom. Where's Mounsieur Cobweb?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>COBWEB</SPEAKER>
+<LINE>Ready.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Mounsieur Cobweb, good mounsieur, get you your</LINE>
+<LINE>weapons in your hand, and kill me a red-hipped</LINE>
+<LINE>humble-bee on the top of a thistle; and, good</LINE>
+<LINE>mounsieur, bring me the honey-bag. Do not fret</LINE>
+<LINE>yourself too much in the action, mounsieur; and,</LINE>
+<LINE>good mounsieur, have a care the honey-bag break not;</LINE>
+<LINE>I would be loath to have you overflown with a</LINE>
+<LINE>honey-bag, signior. Where's Mounsieur Mustardseed?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>MUSTARDSEED</SPEAKER>
+<LINE>Ready.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Give me your neaf, Mounsieur Mustardseed. Pray you,</LINE>
+<LINE>leave your courtesy, good mounsieur.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>MUSTARDSEED</SPEAKER>
+<LINE>What's your Will?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Nothing, good mounsieur, but to help Cavalery Cobweb</LINE>
+<LINE>to scratch. I must to the barber's, monsieur; for</LINE>
+<LINE>methinks I am marvellous hairy about the face; and I</LINE>
+<LINE>am such a tender ass, if my hair do but tickle me,</LINE>
+<LINE>I must scratch.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>What, wilt thou hear some music,</LINE>
+<LINE>my sweet love?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>I have a reasonable good ear in music. Let's have</LINE>
+<LINE>the tongs and the bones.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Or say, sweet love, what thou desirest to eat.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Truly, a peck of provender: I could munch your good</LINE>
+<LINE>dry oats. Methinks I have a great desire to a bottle</LINE>
+<LINE>of hay: good hay, sweet hay, hath no fellow.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>I have a venturous fairy that shall seek</LINE>
+<LINE>The squirrel's hoard, and fetch thee new nuts.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>I had rather have a handful or two of dried peas.</LINE>
+<LINE>But, I pray you, let none of your people stir me: I</LINE>
+<LINE>have an exposition of sleep come upon me.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Sleep thou, and I will wind thee in my arms.</LINE>
+<LINE>Fairies, begone, and be all ways away.</LINE>
+<STAGEDIR>Exeunt fairies</STAGEDIR>
+<LINE>So doth the woodbine the sweet honeysuckle</LINE>
+<LINE>Gently entwist; the female ivy so</LINE>
+<LINE>Enrings the barky fingers of the elm.</LINE>
+<LINE>O, how I love thee! how I dote on thee!</LINE>
+</SPEECH>
+
+<STAGEDIR>They sleep</STAGEDIR>
+<STAGEDIR>Enter PUCK</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE><STAGEDIR>Advancing</STAGEDIR>  Welcome, good Robin.</LINE>
+<LINE>See'st thou this sweet sight?</LINE>
+<LINE>Her dotage now I do begin to pity:</LINE>
+<LINE>For, meeting her of late behind the wood,</LINE>
+<LINE>Seeking sweet favours from this hateful fool,</LINE>
+<LINE>I did upbraid her and fall out with her;</LINE>
+<LINE>For she his hairy temples then had rounded</LINE>
+<LINE>With a coronet of fresh and fragrant flowers;</LINE>
+<LINE>And that same dew, which sometime on the buds</LINE>
+<LINE>Was wont to swell like round and orient pearls,</LINE>
+<LINE>Stood now within the pretty flowerets' eyes</LINE>
+<LINE>Like tears that did their own disgrace bewail.</LINE>
+<LINE>When I had at my pleasure taunted her</LINE>
+<LINE>And she in mild terms begg'd my patience,</LINE>
+<LINE>I then did ask of her her changeling child;</LINE>
+<LINE>Which straight she gave me, and her fairy sent</LINE>
+<LINE>To bear him to my bower in fairy land.</LINE>
+<LINE>And now I have the boy, I will undo</LINE>
+<LINE>This hateful imperfection of her eyes:</LINE>
+<LINE>And, gentle Puck, take this transformed scalp</LINE>
+<LINE>From off the head of this Athenian swain;</LINE>
+<LINE>That, he awaking when the other do,</LINE>
+<LINE>May all to Athens back again repair</LINE>
+<LINE>And think no more of this night's accidents</LINE>
+<LINE>But as the fierce vexation of a dream.</LINE>
+<LINE>But first I will release the fairy queen.</LINE>
+<LINE>Be as thou wast wont to be;</LINE>
+<LINE>See as thou wast wont to see:</LINE>
+<LINE>Dian's bud o'er Cupid's flower</LINE>
+<LINE>Hath such force and blessed power.</LINE>
+<LINE>Now, my Titania; wake you, my sweet queen.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>My Oberon! what visions have I seen!</LINE>
+<LINE>Methought I was enamour'd of an ass.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>There lies your love.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>How came these things to pass?</LINE>
+<LINE>O, how mine eyes do loathe his visage now!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Silence awhile. Robin, take off this head.</LINE>
+<LINE>Titania, music call; and strike more dead</LINE>
+<LINE>Than common sleep of all these five the sense.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Music, ho! music, such as charmeth sleep!</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Music, still</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Now, when thou wakest, with thine</LINE>
+<LINE>own fool's eyes peep.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Sound, music! Come, my queen, take hands with me,</LINE>
+<LINE>And rock the ground whereon these sleepers be.</LINE>
+<LINE>Now thou and I are new in amity,</LINE>
+<LINE>And will to-morrow midnight solemnly</LINE>
+<LINE>Dance in Duke Theseus' house triumphantly,</LINE>
+<LINE>And bless it to all fair prosperity:</LINE>
+<LINE>There shall the pairs of faithful lovers be</LINE>
+<LINE>Wedded, with Theseus, all in jollity.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Fairy king, attend, and mark:</LINE>
+<LINE>I do hear the morning lark.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Then, my queen, in silence sad,</LINE>
+<LINE>Trip we after the night's shade:</LINE>
+<LINE>We the globe can compass soon,</LINE>
+<LINE>Swifter than the wandering moon.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>Come, my lord, and in our flight</LINE>
+<LINE>Tell me how it came this night</LINE>
+<LINE>That I sleeping here was found</LINE>
+<LINE>With these mortals on the ground.</LINE>
+<STAGEDIR>Exeunt</STAGEDIR>
+</SPEECH>
+
+<STAGEDIR>Horns winded within</STAGEDIR>
+<STAGEDIR>Enter THESEUS, HIPPOLYTA, EGEUS, and train</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Go, one of you, find out the forester;</LINE>
+<LINE>For now our observation is perform'd;</LINE>
+<LINE>And since we have the vaward of the day,</LINE>
+<LINE>My love shall hear the music of my hounds.</LINE>
+<LINE>Uncouple in the western valley; let them go:</LINE>
+<LINE>Dispatch, I say, and find the forester.</LINE>
+<STAGEDIR>Exit an Attendant</STAGEDIR>
+<LINE>We will, fair queen, up to the mountain's top,</LINE>
+<LINE>And mark the musical confusion</LINE>
+<LINE>Of hounds and echo in conjunction.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>I was with Hercules and Cadmus once,</LINE>
+<LINE>When in a wood of Crete they bay'd the bear</LINE>
+<LINE>With hounds of Sparta: never did I hear</LINE>
+<LINE>Such gallant chiding: for, besides the groves,</LINE>
+<LINE>The skies, the fountains, every region near</LINE>
+<LINE>Seem'd all one mutual cry: I never heard</LINE>
+<LINE>So musical a discord, such sweet thunder.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>My hounds are bred out of the Spartan kind,</LINE>
+<LINE>So flew'd, so sanded, and their heads are hung</LINE>
+<LINE>With ears that sweep away the morning dew;</LINE>
+<LINE>Crook-knee'd, and dew-lapp'd like Thessalian bulls;</LINE>
+<LINE>Slow in pursuit, but match'd in mouth like bells,</LINE>
+<LINE>Each under each. A cry more tuneable</LINE>
+<LINE>Was never holla'd to, nor cheer'd with horn,</LINE>
+<LINE>In Crete, in Sparta, nor in Thessaly:</LINE>
+<LINE>Judge when you hear. But, soft! what nymphs are these?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>EGEUS</SPEAKER>
+<LINE>My lord, this is my daughter here asleep;</LINE>
+<LINE>And this, Lysander; this Demetrius is;</LINE>
+<LINE>This Helena, old Nedar's Helena:</LINE>
+<LINE>I wonder of their being here together.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>No doubt they rose up early to observe</LINE>
+<LINE>The rite of May, and hearing our intent,</LINE>
+<LINE>Came here in grace our solemnity.</LINE>
+<LINE>But speak, Egeus; is not this the day</LINE>
+<LINE>That Hermia should give answer of her choice?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>EGEUS</SPEAKER>
+<LINE>It is, my lord.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Go, bid the huntsmen wake them with their horns.</LINE>
+<STAGEDIR>Horns and shout within. LYSANDER, DEMETRIUS,
+HELENA, and HERMIA wake and start up</STAGEDIR>
+<LINE>Good morrow, friends. Saint Valentine is past:</LINE>
+<LINE>Begin these wood-birds but to couple now?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Pardon, my lord.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>I pray you all, stand up.</LINE>
+<LINE>I know you two are rival enemies:</LINE>
+<LINE>How comes this gentle concord in the world,</LINE>
+<LINE>That hatred is so far from jealousy,</LINE>
+<LINE>To sleep by hate, and fear no enmity?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>My lord, I shall reply amazedly,</LINE>
+<LINE>Half sleep, half waking: but as yet, I swear,</LINE>
+<LINE>I cannot truly say how I came here;</LINE>
+<LINE>But, as I think,--for truly would I speak,</LINE>
+<LINE>And now do I bethink me, so it is,--</LINE>
+<LINE>I came with Hermia hither: our intent</LINE>
+<LINE>Was to be gone from Athens, where we might,</LINE>
+<LINE>Without the peril of the Athenian law.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>EGEUS</SPEAKER>
+<LINE>Enough, enough, my lord; you have enough:</LINE>
+<LINE>I beg the law, the law, upon his head.</LINE>
+<LINE>They would have stolen away; they would, Demetrius,</LINE>
+<LINE>Thereby to have defeated you and me,</LINE>
+<LINE>You of your wife and me of my consent,</LINE>
+<LINE>Of my consent that she should be your wife.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>My lord, fair Helen told me of their stealth,</LINE>
+<LINE>Of this their purpose hither to this wood;</LINE>
+<LINE>And I in fury hither follow'd them,</LINE>
+<LINE>Fair Helena in fancy following me.</LINE>
+<LINE>But, my good lord, I wot not by what power,--</LINE>
+<LINE>But by some power it is,--my love to Hermia,</LINE>
+<LINE>Melted as the snow, seems to me now</LINE>
+<LINE>As the remembrance of an idle gaud</LINE>
+<LINE>Which in my childhood I did dote upon;</LINE>
+<LINE>And all the faith, the virtue of my heart,</LINE>
+<LINE>The object and the pleasure of mine eye,</LINE>
+<LINE>Is only Helena. To her, my lord,</LINE>
+<LINE>Was I betroth'd ere I saw Hermia:</LINE>
+<LINE>But, like in sickness, did I loathe this food;</LINE>
+<LINE>But, as in health, come to my natural taste,</LINE>
+<LINE>Now I do wish it, love it, long for it,</LINE>
+<LINE>And will for evermore be true to it.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Fair lovers, you are fortunately met:</LINE>
+<LINE>Of this discourse we more will hear anon.</LINE>
+<LINE>Egeus, I will overbear your will;</LINE>
+<LINE>For in the temple by and by with us</LINE>
+<LINE>These couples shall eternally be knit:</LINE>
+<LINE>And, for the morning now is something worn,</LINE>
+<LINE>Our purposed hunting shall be set aside.</LINE>
+<LINE>Away with us to Athens; three and three,</LINE>
+<LINE>We'll hold a feast in great solemnity.</LINE>
+<LINE>Come, Hippolyta.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt THESEUS, HIPPOLYTA, EGEUS, and train</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>These things seem small and undistinguishable,</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Methinks I see these things with parted eye,</LINE>
+<LINE>When every thing seems double.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>So methinks:</LINE>
+<LINE>And I have found Demetrius like a jewel,</LINE>
+<LINE>Mine own, and not mine own.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Are you sure</LINE>
+<LINE>That we are awake? It seems to me</LINE>
+<LINE>That yet we sleep, we dream. Do not you think</LINE>
+<LINE>The duke was here, and bid us follow him?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HERMIA</SPEAKER>
+<LINE>Yea; and my father.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HELENA</SPEAKER>
+<LINE>And Hippolyta.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>And he did bid us follow to the temple.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Why, then, we are awake: let's follow him</LINE>
+<LINE>And by the way let us recount our dreams.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE><STAGEDIR>Awaking</STAGEDIR>  When my cue comes, call me, and I will</LINE>
+<LINE>answer: my next is, 'Most fair Pyramus.' Heigh-ho!</LINE>
+<LINE>Peter Quince! Flute, the bellows-mender! Snout,</LINE>
+<LINE>the tinker! Starveling! God's my life, stolen</LINE>
+<LINE>hence, and left me asleep! I have had a most rare</LINE>
+<LINE>vision. I have had a dream, past the wit of man to</LINE>
+<LINE>say what dream it was: man is but an ass, if he go</LINE>
+<LINE>about to expound this dream. Methought I was--there</LINE>
+<LINE>is no man can tell what. Methought I was,--and</LINE>
+<LINE>methought I had,--but man is but a patched fool, if</LINE>
+<LINE>he will offer to say what methought I had. The eye</LINE>
+<LINE>of man hath not heard, the ear of man hath not</LINE>
+<LINE>seen, man's hand is not able to taste, his tongue</LINE>
+<LINE>to conceive, nor his heart to report, what my dream</LINE>
+<LINE>was. I will get Peter Quince to write a ballad of</LINE>
+<LINE>this dream: it shall be called Bottom's Dream,</LINE>
+<LINE>because it hath no bottom; and I will sing it in the</LINE>
+<LINE>latter end of a play, before the duke:</LINE>
+<LINE>peradventure, to make it the more gracious, I shall</LINE>
+<LINE>sing it at her death.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+</SCENE>
+
+<SCENE><TITLE>SCENE II.  Athens. QUINCE'S house.</TITLE>
+<STAGEDIR>Enter QUINCE, FLUTE, SNOUT, and STARVELING</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Have you sent to Bottom's house? is he come home yet?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>STARVELING</SPEAKER>
+<LINE>He cannot be heard of. Out of doubt he is</LINE>
+<LINE>transported.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>If he come not, then the play is marred: it goes</LINE>
+<LINE>not forward, doth it?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>It is not possible: you have not a man in all</LINE>
+<LINE>Athens able to discharge Pyramus but he.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>No, he hath simply the best wit of any handicraft</LINE>
+<LINE>man in Athens.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Yea and the best person too; and he is a very</LINE>
+<LINE>paramour for a sweet voice.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>You must say 'paragon:' a paramour is, God bless us,</LINE>
+<LINE>a thing of naught.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter SNUG</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>SNUG</SPEAKER>
+<LINE>Masters, the duke is coming from the temple, and</LINE>
+<LINE>there is two or three lords and ladies more married:</LINE>
+<LINE>if our sport had gone forward, we had all been made</LINE>
+<LINE>men.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>FLUTE</SPEAKER>
+<LINE>O sweet bully Bottom! Thus hath he lost sixpence a</LINE>
+<LINE>day during his life; he could not have 'scaped</LINE>
+<LINE>sixpence a day: an the duke had not given him</LINE>
+<LINE>sixpence a day for playing Pyramus, I'll be hanged;</LINE>
+<LINE>he would have deserved it: sixpence a day in</LINE>
+<LINE>Pyramus, or nothing.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter BOTTOM</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Where are these lads? where are these hearts?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Bottom! O most courageous day! O most happy hour!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Masters, I am to discourse wonders: but ask me not</LINE>
+<LINE>what; for if I tell you, I am no true Athenian. I</LINE>
+<LINE>will tell you every thing, right as it fell out.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>QUINCE</SPEAKER>
+<LINE>Let us hear, sweet Bottom.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE>Not a word of me. All that I will tell you is, that</LINE>
+<LINE>the duke hath dined. Get your apparel together,</LINE>
+<LINE>good strings to your beards, new ribbons to your</LINE>
+<LINE>pumps; meet presently at the palace; every man look</LINE>
+<LINE>o'er his part; for the short and the long is, our</LINE>
+<LINE>play is preferred. In any case, let Thisby have</LINE>
+<LINE>clean linen; and let not him that plays the lion</LINE>
+<LINE>pair his nails, for they shall hang out for the</LINE>
+<LINE>lion's claws. And, most dear actors, eat no onions</LINE>
+<LINE>nor garlic, for we are to utter sweet breath; and I</LINE>
+<LINE>do not doubt but to hear them say, it is a sweet</LINE>
+<LINE>comedy. No more words: away! go, away!</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt</STAGEDIR>
+</SCENE>
+
+</ACT>
+
+<ACT><TITLE>ACT V</TITLE>
+
+<SCENE><TITLE>SCENE I.  Athens. The palace of THESEUS.</TITLE>
+<STAGEDIR>Enter THESEUS, HIPPOLYTA, PHILOSTRATE, Lords and
+Attendants</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>'Tis strange my Theseus, that these</LINE>
+<LINE>lovers speak of.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>More strange than true: I never may believe</LINE>
+<LINE>These antique fables, nor these fairy toys.</LINE>
+<LINE>Lovers and madmen have such seething brains,</LINE>
+<LINE>Such shaping fantasies, that apprehend</LINE>
+<LINE>More than cool reason ever comprehends.</LINE>
+<LINE>The lunatic, the lover and the poet</LINE>
+<LINE>Are of imagination all compact:</LINE>
+<LINE>One sees more devils than vast hell can hold,</LINE>
+<LINE>That is, the madman: the lover, all as frantic,</LINE>
+<LINE>Sees Helen's beauty in a brow of Egypt:</LINE>
+<LINE>The poet's eye, in fine frenzy rolling,</LINE>
+<LINE>Doth glance from heaven to earth, from earth to heaven;</LINE>
+<LINE>And as imagination bodies forth</LINE>
+<LINE>The forms of things unknown, the poet's pen</LINE>
+<LINE>Turns them to shapes and gives to airy nothing</LINE>
+<LINE>A local habitation and a name.</LINE>
+<LINE>Such tricks hath strong imagination,</LINE>
+<LINE>That if it would but apprehend some joy,</LINE>
+<LINE>It comprehends some bringer of that joy;</LINE>
+<LINE>Or in the night, imagining some fear,</LINE>
+<LINE>How easy is a bush supposed a bear!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>But all the story of the night told over,</LINE>
+<LINE>And all their minds transfigured so together,</LINE>
+<LINE>More witnesseth than fancy's images</LINE>
+<LINE>And grows to something of great constancy;</LINE>
+<LINE>But, howsoever, strange and admirable.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Here come the lovers, full of joy and mirth.</LINE>
+<STAGEDIR>Enter LYSANDER, DEMETRIUS, HERMIA, and HELENA</STAGEDIR>
+<LINE>Joy, gentle friends! joy and fresh days of love</LINE>
+<LINE>Accompany your hearts!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>More than to us</LINE>
+<LINE>Wait in your royal walks, your board, your bed!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Come now; what masques, what dances shall we have,</LINE>
+<LINE>To wear away this long age of three hours</LINE>
+<LINE>Between our after-supper and bed-time?</LINE>
+<LINE>Where is our usual manager of mirth?</LINE>
+<LINE>What revels are in hand? Is there no play,</LINE>
+<LINE>To ease the anguish of a torturing hour?</LINE>
+<LINE>Call Philostrate.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PHILOSTRATE</SPEAKER>
+<LINE>Here, mighty Theseus.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Say, what abridgement have you for this evening?</LINE>
+<LINE>What masque? what music? How shall we beguile</LINE>
+<LINE>The lazy time, if not with some delight?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PHILOSTRATE</SPEAKER>
+<LINE>There is a brief how many sports are ripe:</LINE>
+<LINE>Make choice of which your highness will see first.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Giving a paper</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE><STAGEDIR>Reads</STAGEDIR>  'The battle with the Centaurs, to be sung</LINE>
+<LINE>By an Athenian eunuch to the harp.'</LINE>
+<LINE>We'll none of that: that have I told my love,</LINE>
+<LINE>In glory of my kinsman Hercules.</LINE>
+<STAGEDIR>Reads</STAGEDIR>
+<LINE>'The riot of the tipsy Bacchanals,</LINE>
+<LINE>Tearing the Thracian singer in their rage.'</LINE>
+<LINE>That is an old device; and it was play'd</LINE>
+<LINE>When I from Thebes came last a conqueror.</LINE>
+<STAGEDIR>Reads</STAGEDIR>
+<LINE>'The thrice three Muses mourning for the death</LINE>
+<LINE>Of Learning, late deceased in beggary.'</LINE>
+<LINE>That is some satire, keen and critical,</LINE>
+<LINE>Not sorting with a nuptial ceremony.</LINE>
+<STAGEDIR>Reads</STAGEDIR>
+<LINE>'A tedious brief scene of young Pyramus</LINE>
+<LINE>And his love Thisbe; very tragical mirth.'</LINE>
+<LINE>Merry and tragical! tedious and brief!</LINE>
+<LINE>That is, hot ice and wondrous strange snow.</LINE>
+<LINE>How shall we find the concord of this discord?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PHILOSTRATE</SPEAKER>
+<LINE>A play there is, my lord, some ten words long,</LINE>
+<LINE>Which is as brief as I have known a play;</LINE>
+<LINE>But by ten words, my lord, it is too long,</LINE>
+<LINE>Which makes it tedious; for in all the play</LINE>
+<LINE>There is not one word apt, one player fitted:</LINE>
+<LINE>And tragical, my noble lord, it is;</LINE>
+<LINE>For Pyramus therein doth kill himself.</LINE>
+<LINE>Which, when I saw rehearsed, I must confess,</LINE>
+<LINE>Made mine eyes water; but more merry tears</LINE>
+<LINE>The passion of loud laughter never shed.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>What are they that do play it?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PHILOSTRATE</SPEAKER>
+<LINE>Hard-handed men that work in Athens here,</LINE>
+<LINE>Which never labour'd in their minds till now,</LINE>
+<LINE>And now have toil'd their unbreathed memories</LINE>
+<LINE>With this same play, against your nuptial.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>And we will hear it.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>PHILOSTRATE</SPEAKER>
+<LINE>No, my noble lord;</LINE>
+<LINE>It is not for you: I have heard it over,</LINE>
+<LINE>And it is nothing, nothing in the world;</LINE>
+<LINE>Unless you can find sport in their intents,</LINE>
+<LINE>Extremely stretch'd and conn'd with cruel pain,</LINE>
+<LINE>To do you service.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>I will hear that play;</LINE>
+<LINE>For never anything can be amiss,</LINE>
+<LINE>When simpleness and duty tender it.</LINE>
+<LINE>Go, bring them in: and take your places, ladies.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit PHILOSTRATE</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>I love not to see wretchedness o'er charged</LINE>
+<LINE>And duty in his service perishing.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Why, gentle sweet, you shall see no such thing.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>He says they can do nothing in this kind.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>The kinder we, to give them thanks for nothing.</LINE>
+<LINE>Our sport shall be to take what they mistake:</LINE>
+<LINE>And what poor duty cannot do, noble respect</LINE>
+<LINE>Takes it in might, not merit.</LINE>
+<LINE>Where I have come, great clerks have purposed</LINE>
+<LINE>To greet me with premeditated welcomes;</LINE>
+<LINE>Where I have seen them shiver and look pale,</LINE>
+<LINE>Make periods in the midst of sentences,</LINE>
+<LINE>Throttle their practised accent in their fears</LINE>
+<LINE>And in conclusion dumbly have broke off,</LINE>
+<LINE>Not paying me a welcome. Trust me, sweet,</LINE>
+<LINE>Out of this silence yet I pick'd a welcome;</LINE>
+<LINE>And in the modesty of fearful duty</LINE>
+<LINE>I read as much as from the rattling tongue</LINE>
+<LINE>Of saucy and audacious eloquence.</LINE>
+<LINE>Love, therefore, and tongue-tied simplicity</LINE>
+<LINE>In least speak most, to my capacity.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Re-enter PHILOSTRATE</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PHILOSTRATE</SPEAKER>
+<LINE>So please your grace, the Prologue is address'd.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Let him approach.</LINE>
+</SPEECH>
+
+<STAGEDIR>Flourish of trumpets</STAGEDIR>
+<STAGEDIR>Enter QUINCE for the Prologue</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>Prologue</SPEAKER>
+<LINE>If we offend, it is with our good will.</LINE>
+<LINE>That you should think, we come not to offend,</LINE>
+<LINE>But with good will. To show our simple skill,</LINE>
+<LINE>That is the true beginning of our end.</LINE>
+<LINE>Consider then we come but in despite.</LINE>
+<LINE>We do not come as minding to contest you,</LINE>
+<LINE>Our true intent is. All for your delight</LINE>
+<LINE>We are not here. That you should here repent you,</LINE>
+<LINE>The actors are at hand and by their show</LINE>
+<LINE>You shall know all that you are like to know.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>This fellow doth not stand upon points.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>He hath rid his prologue like a rough colt; he knows</LINE>
+<LINE>not the stop. A good moral, my lord: it is not</LINE>
+<LINE>enough to speak, but to speak true.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>Indeed he hath played on his prologue like a child</LINE>
+<LINE>on a recorder; a sound, but not in government.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>His speech, was like a tangled chain; nothing</LINE>
+<LINE>impaired, but all disordered. Who is next?</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter Pyramus and Thisbe, Wall, Moonshine, and Lion</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>Prologue</SPEAKER>
+<LINE>Gentles, perchance you wonder at this show;</LINE>
+<LINE>But wonder on, till truth make all things plain.</LINE>
+<LINE>This man is Pyramus, if you would know;</LINE>
+<LINE>This beauteous lady Thisby is certain.</LINE>
+<LINE>This man, with lime and rough-cast, doth present</LINE>
+<LINE>Wall, that vile Wall which did these lovers sunder;</LINE>
+<LINE>And through Wall's chink, poor souls, they are content</LINE>
+<LINE>To whisper. At the which let no man wonder.</LINE>
+<LINE>This man, with lanthorn, dog, and bush of thorn,</LINE>
+<LINE>Presenteth Moonshine; for, if you will know,</LINE>
+<LINE>By moonshine did these lovers think no scorn</LINE>
+<LINE>To meet at Ninus' tomb, there, there to woo.</LINE>
+<LINE>This grisly beast, which Lion hight by name,</LINE>
+<LINE>The trusty Thisby, coming first by night,</LINE>
+<LINE>Did scare away, or rather did affright;</LINE>
+<LINE>And, as she fled, her mantle she did fall,</LINE>
+<LINE>Which Lion vile with bloody mouth did stain.</LINE>
+<LINE>Anon comes Pyramus, sweet youth and tall,</LINE>
+<LINE>And finds his trusty Thisby's mantle slain:</LINE>
+<LINE>Whereat, with blade, with bloody blameful blade,</LINE>
+<LINE>He bravely broach'd is boiling bloody breast;</LINE>
+<LINE>And Thisby, tarrying in mulberry shade,</LINE>
+<LINE>His dagger drew, and died. For all the rest,</LINE>
+<LINE>Let Lion, Moonshine, Wall, and lovers twain</LINE>
+<LINE>At large discourse, while here they do remain.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt Prologue, Thisbe, Lion, and Moonshine</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>I wonder if the lion be to speak.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>No wonder, my lord: one lion may, when many asses do.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Wall</SPEAKER>
+<LINE>In this same interlude it doth befall</LINE>
+<LINE>That I, one Snout by name, present a wall;</LINE>
+<LINE>And such a wall, as I would have you think,</LINE>
+<LINE>That had in it a crannied hole or chink,</LINE>
+<LINE>Through which the lovers, Pyramus and Thisby,</LINE>
+<LINE>Did whisper often very secretly.</LINE>
+<LINE>This loam, this rough-cast and this stone doth show</LINE>
+<LINE>That I am that same wall; the truth is so:</LINE>
+<LINE>And this the cranny is, right and sinister,</LINE>
+<LINE>Through which the fearful lovers are to whisper.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Would you desire lime and hair to speak better?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>It is the wittiest partition that ever I heard</LINE>
+<LINE>discourse, my lord.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter Pyramus</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Pyramus draws near the wall: silence!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Pyramus</SPEAKER>
+<LINE>O grim-look'd night! O night with hue so black!</LINE>
+<LINE>O night, which ever art when day is not!</LINE>
+<LINE>O night, O night! alack, alack, alack,</LINE>
+<LINE>I fear my Thisby's promise is forgot!</LINE>
+<LINE>And thou, O wall, O sweet, O lovely wall,</LINE>
+<LINE>That stand'st between her father's ground and mine!</LINE>
+<LINE>Thou wall, O wall, O sweet and lovely wall,</LINE>
+<LINE>Show me thy chink, to blink through with mine eyne!</LINE>
+<STAGEDIR>Wall holds up his fingers</STAGEDIR>
+<LINE>Thanks, courteous wall: Jove shield thee well for this!</LINE>
+<LINE>But what see I? No Thisby do I see.</LINE>
+<LINE>O wicked wall, through whom I see no bliss!</LINE>
+<LINE>Cursed be thy stones for thus deceiving me!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>The wall, methinks, being sensible, should curse again.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Pyramus</SPEAKER>
+<LINE>No, in truth, sir, he should not. 'Deceiving me'</LINE>
+<LINE>is Thisby's cue: she is to enter now, and I am to</LINE>
+<LINE>spy her through the wall. You shall see, it will</LINE>
+<LINE>fall pat as I told you. Yonder she comes.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter Thisbe</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>Thisbe</SPEAKER>
+<LINE>O wall, full often hast thou heard my moans,</LINE>
+<LINE>For parting my fair Pyramus and me!</LINE>
+<LINE>My cherry lips have often kiss'd thy stones,</LINE>
+<LINE>Thy stones with lime and hair knit up in thee.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Pyramus</SPEAKER>
+<LINE>I see a voice: now will I to the chink,</LINE>
+<LINE>To spy an I can hear my Thisby's face. Thisby!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Thisbe</SPEAKER>
+<LINE>My love thou art, my love I think.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Pyramus</SPEAKER>
+<LINE>Think what thou wilt, I am thy lover's grace;</LINE>
+<LINE>And, like Limander, am I trusty still.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Thisbe</SPEAKER>
+<LINE>And I like Helen, till the Fates me kill.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Pyramus</SPEAKER>
+<LINE>Not Shafalus to Procrus was so true.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Thisbe</SPEAKER>
+<LINE>As Shafalus to Procrus, I to you.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Pyramus</SPEAKER>
+<LINE>O kiss me through the hole of this vile wall!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Thisbe</SPEAKER>
+<LINE>I kiss the wall's hole, not your lips at all.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Pyramus</SPEAKER>
+<LINE>Wilt thou at Ninny's tomb meet me straightway?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Thisbe</SPEAKER>
+<LINE>'Tide life, 'tide death, I come without delay.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt Pyramus and Thisbe</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>Wall</SPEAKER>
+<LINE>Thus have I, Wall, my part discharged so;</LINE>
+<LINE>And, being done, thus Wall away doth go.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Now is the mural down between the two neighbours.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>No remedy, my lord, when walls are so wilful to hear</LINE>
+<LINE>without warning.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>This is the silliest stuff that ever I heard.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>The best in this kind are but shadows; and the worst</LINE>
+<LINE>are no worse, if imagination amend them.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>It must be your imagination then, and not theirs.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>If we imagine no worse of them than they of</LINE>
+<LINE>themselves, they may pass for excellent men. Here</LINE>
+<LINE>come two noble beasts in, a man and a lion.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter Lion and Moonshine</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>Lion</SPEAKER>
+<LINE>You, ladies, you, whose gentle hearts do fear</LINE>
+<LINE>The smallest monstrous mouse that creeps on floor,</LINE>
+<LINE>May now perchance both quake and tremble here,</LINE>
+<LINE>When lion rough in wildest rage doth roar.</LINE>
+<LINE>Then know that I, one Snug the joiner, am</LINE>
+<LINE>A lion-fell, nor else no lion's dam;</LINE>
+<LINE>For, if I should as lion come in strife</LINE>
+<LINE>Into this place, 'twere pity on my life.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>A very gentle beast, of a good conscience.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>The very best at a beast, my lord, that e'er I saw.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>This lion is a very fox for his valour.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>True; and a goose for his discretion.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Not so, my lord; for his valour cannot carry his</LINE>
+<LINE>discretion; and the fox carries the goose.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>His discretion, I am sure, cannot carry his valour;</LINE>
+<LINE>for the goose carries not the fox. It is well:</LINE>
+<LINE>leave it to his discretion, and let us listen to the moon.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Moonshine</SPEAKER>
+<LINE>This lanthorn doth the horned moon present;--</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>He should have worn the horns on his head.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>He is no crescent, and his horns are</LINE>
+<LINE>invisible within the circumference.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Moonshine</SPEAKER>
+<LINE>This lanthorn doth the horned moon present;</LINE>
+<LINE>Myself the man i' the moon do seem to be.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>This is the greatest error of all the rest: the man</LINE>
+<LINE>should be put into the lanthorn. How is it else the</LINE>
+<LINE>man i' the moon?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>He dares not come there for the candle; for, you</LINE>
+<LINE>see, it is already in snuff.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>I am aweary of this moon: would he would change!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>It appears, by his small light of discretion, that</LINE>
+<LINE>he is in the wane; but yet, in courtesy, in all</LINE>
+<LINE>reason, we must stay the time.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Proceed, Moon.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Moonshine</SPEAKER>
+<LINE>All that I have to say, is, to tell you that the</LINE>
+<LINE>lanthorn is the moon; I, the man in the moon; this</LINE>
+<LINE>thorn-bush, my thorn-bush; and this dog, my dog.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Why, all these should be in the lanthorn; for all</LINE>
+<LINE>these are in the moon. But, silence! here comes Thisbe.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter Thisbe</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>Thisbe</SPEAKER>
+<LINE>This is old Ninny's tomb. Where is my love?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Lion</SPEAKER>
+<LINE><STAGEDIR>Roaring</STAGEDIR>  Oh--</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Thisbe runs off</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Well roared, Lion.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Well run, Thisbe.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>Well shone, Moon. Truly, the moon shines with a</LINE>
+<LINE>good grace.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>The Lion shakes Thisbe's mantle, and exit</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Well moused, Lion.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>And so the lion vanished.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>And then came Pyramus.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter Pyramus</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>Pyramus</SPEAKER>
+<LINE>Sweet Moon, I thank thee for thy sunny beams;</LINE>
+<LINE>I thank thee, Moon, for shining now so bright;</LINE>
+<LINE>For, by thy gracious, golden, glittering gleams,</LINE>
+<LINE>I trust to take of truest Thisby sight.</LINE>
+<LINE>But stay, O spite!</LINE>
+<LINE>But mark, poor knight,</LINE>
+<LINE>What dreadful dole is here!</LINE>
+<LINE>Eyes, do you see?</LINE>
+<LINE>How can it be?</LINE>
+<LINE>O dainty duck! O dear!</LINE>
+<LINE>Thy mantle good,</LINE>
+<LINE>What, stain'd with blood!</LINE>
+<LINE>Approach, ye Furies fell!</LINE>
+<LINE>O Fates, come, come,</LINE>
+<LINE>Cut thread and thrum;</LINE>
+<LINE>Quail, crush, conclude, and quell!</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>This passion, and the death of a dear friend, would</LINE>
+<LINE>go near to make a man look sad.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>Beshrew my heart, but I pity the man.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Pyramus</SPEAKER>
+<LINE>O wherefore, Nature, didst thou lions frame?</LINE>
+<LINE>Since lion vile hath here deflower'd my dear:</LINE>
+<LINE>Which is--no, no--which was the fairest dame</LINE>
+<LINE>That lived, that loved, that liked, that look'd</LINE>
+<LINE>with cheer.</LINE>
+<LINE>Come, tears, confound;</LINE>
+<LINE>Out, sword, and wound</LINE>
+<LINE>The pap of Pyramus;</LINE>
+<LINE>Ay, that left pap,</LINE>
+<LINE>Where heart doth hop:</LINE>
+<STAGEDIR>Stabs himself</STAGEDIR>
+<LINE>Thus die I, thus, thus, thus.</LINE>
+<LINE>Now am I dead,</LINE>
+<LINE>Now am I fled;</LINE>
+<LINE>My soul is in the sky:</LINE>
+<LINE>Tongue, lose thy light;</LINE>
+<LINE>Moon take thy flight:</LINE>
+<STAGEDIR>Exit Moonshine</STAGEDIR>
+<LINE>Now die, die, die, die, die.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Dies</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>No die, but an ace, for him; for he is but one.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>Less than an ace, man; for he is dead; he is nothing.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>With the help of a surgeon he might yet recover, and</LINE>
+<LINE>prove an ass.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>How chance Moonshine is gone before Thisbe comes</LINE>
+<LINE>back and finds her lover?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>She will find him by starlight. Here she comes; and</LINE>
+<LINE>her passion ends the play.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Re-enter Thisbe</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>HIPPOLYTA</SPEAKER>
+<LINE>Methinks she should not use a long one for such a</LINE>
+<LINE>Pyramus: I hope she will be brief.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>A mote will turn the balance, which Pyramus, which</LINE>
+<LINE>Thisbe, is the better; he for a man, God warrant us;</LINE>
+<LINE>she for a woman, God bless us.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>LYSANDER</SPEAKER>
+<LINE>She hath spied him already with those sweet eyes.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>And thus she means, videlicet:--</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>Thisbe</SPEAKER>
+<LINE>Asleep, my love?</LINE>
+<LINE>What, dead, my dove?</LINE>
+<LINE>O Pyramus, arise!</LINE>
+<LINE>Speak, speak. Quite dumb?</LINE>
+<LINE>Dead, dead? A tomb</LINE>
+<LINE>Must cover thy sweet eyes.</LINE>
+<LINE>These My lips,</LINE>
+<LINE>This cherry nose,</LINE>
+<LINE>These yellow cowslip cheeks,</LINE>
+<LINE>Are gone, are gone:</LINE>
+<LINE>Lovers, make moan:</LINE>
+<LINE>His eyes were green as leeks.</LINE>
+<LINE>O Sisters Three,</LINE>
+<LINE>Come, come to me,</LINE>
+<LINE>With hands as pale as milk;</LINE>
+<LINE>Lay them in gore,</LINE>
+<LINE>Since you have shore</LINE>
+<LINE>With shears his thread of silk.</LINE>
+<LINE>Tongue, not a word:</LINE>
+<LINE>Come, trusty sword;</LINE>
+<LINE>Come, blade, my breast imbrue:</LINE>
+<STAGEDIR>Stabs herself</STAGEDIR>
+<LINE>And, farewell, friends;</LINE>
+<LINE>Thus Thisby ends:</LINE>
+<LINE>Adieu, adieu, adieu.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Dies</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>Moonshine and Lion are left to bury the dead.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>DEMETRIUS</SPEAKER>
+<LINE>Ay, and Wall too.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>BOTTOM</SPEAKER>
+<LINE><STAGEDIR>Starting up</STAGEDIR>  No assure you; the wall is down that</LINE>
+<LINE>parted their fathers. Will it please you to see the</LINE>
+<LINE>epilogue, or to hear a Bergomask dance between two</LINE>
+<LINE>of our company?</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>THESEUS</SPEAKER>
+<LINE>No epilogue, I pray you; for your play needs no</LINE>
+<LINE>excuse. Never excuse; for when the players are all</LINE>
+<LINE>dead, there needs none to be blamed. Marry, if he</LINE>
+<LINE>that writ it had played Pyramus and hanged himself</LINE>
+<LINE>in Thisbe's garter, it would have been a fine</LINE>
+<LINE>tragedy: and so it is, truly; and very notably</LINE>
+<LINE>discharged. But come, your Bergomask: let your</LINE>
+<LINE>epilogue alone.</LINE>
+<STAGEDIR>A dance</STAGEDIR>
+<LINE>The iron tongue of midnight hath told twelve:</LINE>
+<LINE>Lovers, to bed; 'tis almost fairy time.</LINE>
+<LINE>I fear we shall out-sleep the coming morn</LINE>
+<LINE>As much as we this night have overwatch'd.</LINE>
+<LINE>This palpable-gross play hath well beguiled</LINE>
+<LINE>The heavy gait of night. Sweet friends, to bed.</LINE>
+<LINE>A fortnight hold we this solemnity,</LINE>
+<LINE>In nightly revels and new jollity.</LINE>
+</SPEECH>
+
+<STAGEDIR>Exeunt</STAGEDIR>
+<STAGEDIR>Enter PUCK</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>Now the hungry lion roars,</LINE>
+<LINE>And the wolf behowls the moon;</LINE>
+<LINE>Whilst the heavy ploughman snores,</LINE>
+<LINE>All with weary task fordone.</LINE>
+<LINE>Now the wasted brands do glow,</LINE>
+<LINE>Whilst the screech-owl, screeching loud,</LINE>
+<LINE>Puts the wretch that lies in woe</LINE>
+<LINE>In remembrance of a shroud.</LINE>
+<LINE>Now it is the time of night</LINE>
+<LINE>That the graves all gaping wide,</LINE>
+<LINE>Every one lets forth his sprite,</LINE>
+<LINE>In the church-way paths to glide:</LINE>
+<LINE>And we fairies, that do run</LINE>
+<LINE>By the triple Hecate's team,</LINE>
+<LINE>From the presence of the sun,</LINE>
+<LINE>Following darkness like a dream,</LINE>
+<LINE>Now are frolic: not a mouse</LINE>
+<LINE>Shall disturb this hallow'd house:</LINE>
+<LINE>I am sent with broom before,</LINE>
+<LINE>To sweep the dust behind the door.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Enter OBERON and TITANIA with their train</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Through the house give gathering light,</LINE>
+<LINE>By the dead and drowsy fire:</LINE>
+<LINE>Every elf and fairy sprite</LINE>
+<LINE>Hop as light as bird from brier;</LINE>
+<LINE>And this ditty, after me,</LINE>
+<LINE>Sing, and dance it trippingly.</LINE>
+</SPEECH>
+
+<SPEECH>
+<SPEAKER>TITANIA</SPEAKER>
+<LINE>First, rehearse your song by rote</LINE>
+<LINE>To each word a warbling note:</LINE>
+<LINE>Hand in hand, with fairy grace,</LINE>
+<LINE>Will we sing, and bless this place.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Song and dance</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>OBERON</SPEAKER>
+<LINE>Now, until the break of day,</LINE>
+<LINE>Through this house each fairy stray.</LINE>
+<LINE>To the best bride-bed will we,</LINE>
+<LINE>Which by us shall blessed be;</LINE>
+<LINE>And the issue there create</LINE>
+<LINE>Ever shall be fortunate.</LINE>
+<LINE>So shall all the couples three</LINE>
+<LINE>Ever true in loving be;</LINE>
+<LINE>And the blots of Nature's hand</LINE>
+<LINE>Shall not in their issue stand;</LINE>
+<LINE>Never mole, hare lip, nor scar,</LINE>
+<LINE>Nor mark prodigious, such as are</LINE>
+<LINE>Despised in nativity,</LINE>
+<LINE>Shall upon their children be.</LINE>
+<LINE>With this field-dew consecrate,</LINE>
+<LINE>Every fairy take his gait;</LINE>
+<LINE>And each several chamber bless,</LINE>
+<LINE>Through this palace, with sweet peace;</LINE>
+<LINE>And the owner of it blest</LINE>
+<LINE>Ever shall in safety rest.</LINE>
+<LINE>Trip away; make no stay;</LINE>
+<LINE>Meet me all by break of day.</LINE>
+</SPEECH>
+
+
+<STAGEDIR>Exeunt OBERON, TITANIA, and train</STAGEDIR>
+
+<SPEECH>
+<SPEAKER>PUCK</SPEAKER>
+<LINE>If we shadows have offended,</LINE>
+<LINE>Think but this, and all is mended,</LINE>
+<LINE>That you have but slumber'd here</LINE>
+<LINE>While these visions did appear.</LINE>
+<LINE>And this weak and idle theme,</LINE>
+<LINE>No more yielding but a dream,</LINE>
+<LINE>Gentles, do not reprehend:</LINE>
+<LINE>if you pardon, we will mend:</LINE>
+<LINE>And, as I am an honest Puck,</LINE>
+<LINE>If we have unearned luck</LINE>
+<LINE>Now to 'scape the serpent's tongue,</LINE>
+<LINE>We will make amends ere long;</LINE>
+<LINE>Else the Puck a liar call;</LINE>
+<LINE>So, good night unto you all.</LINE>
+<LINE>Give me your hands, if we be friends,</LINE>
+<LINE>And Robin shall restore amends.</LINE>
+</SPEECH>
+</SCENE>
+</ACT>
+</PLAY>

--- a/tinyxml2-3.0.0/resources/utf8test.xml
+++ b/tinyxml2-3.0.0/resources/utf8test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <English name="name" value="value">The world has many languages</English>
+    <Russian name="название(имя)" value="ценность">Мир имеет много языков</Russian>
+    <Spanish name="el nombre" value="el valor">el mundo tiene muchos idiomas</Spanish>
+    <SimplifiedChinese name="名字" value="价值">世界有很多语言</SimplifiedChinese>
+    <Русский название="name" ценность="value">&lt;имеет&gt;</Русский>
+    <汉语 名字="name" 价值="value">世界有很多语言</汉语>
+    <Heavy>"M&#x0eB;t&#230;l!"</Heavy>
+    <ä>Umlaut Element</ä>
+</document>

--- a/tinyxml2-3.0.0/resources/utf8testverify.xml
+++ b/tinyxml2-3.0.0/resources/utf8testverify.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+    <English name="name" value="value">The world has many languages</English>
+    <Russian name="название(имя)" value="ценность">Мир имеет много языков</Russian>
+    <Spanish name="el nombre" value="el valor">el mundo tiene muchos idiomas</Spanish>
+    <SimplifiedChinese name="名字" value="价值">世界有很多语言</SimplifiedChinese>
+    <Русский название="name" ценность="value">&lt;имеет&gt;</Русский>
+    <汉语 名字="name" 价值="value">世界有很多语言</汉语>
+    <Heavy>"Mëtæl!"</Heavy>
+    <ä>Umlaut Element</ä>
+</document>

--- a/tinyxml2-3.0.0/setversion.py
+++ b/tinyxml2-3.0.0/setversion.py
@@ -1,0 +1,123 @@
+# Python program to set the version.
+##############################################
+
+import re
+import sys
+import optparse
+
+def fileProcess( name, lineFunction ):
+	filestream = open( name, 'r' )
+	if filestream.closed:
+		print( "file " + name + " not open." )
+		return
+
+	output = ""
+	print( "--- Processing " + name + " ---------" )
+	while 1:
+		line = filestream.readline()
+		if not line: break
+		output += lineFunction( line )
+	filestream.close()
+	
+	if not output: return			# basic error checking
+	
+	print( "Writing file " + name )
+	filestream = open( name, "w" );
+	filestream.write( output );
+	filestream.close()
+	
+def echoInput( line ):
+	return line
+
+parser = optparse.OptionParser( "usage: %prog major minor build" )
+(options, args) = parser.parse_args()
+if len(args) != 3:
+	parser.error( "incorrect number of arguments" );
+
+major = args[0]
+minor = args[1]
+build = args[2]
+versionStr = major + "." + minor + "." + build
+
+print ("Setting dox,tinyxml2.h")
+print ("Version: " + major + "." + minor + "." + build)
+
+#### Write the tinyxml.h ####
+
+def engineRule( line ):
+
+	matchMajor = "static const int TIXML2_MAJOR_VERSION"
+	matchMinor = "static const int TIXML2_MINOR_VERSION"
+	matchBuild = "static const int TIXML2_PATCH_VERSION"
+
+	if line[0:len(matchMajor)] == matchMajor:
+		print( "1)tinyxml2.h Major found" )
+		return matchMajor + " = " + major + ";\n"
+
+	elif line[0:len(matchMinor)] == matchMinor:
+		print( "2)tinyxml2.h Minor found" )
+		return matchMinor + " = " + minor + ";\n"
+
+	elif line[0:len(matchBuild)] == matchBuild:
+		print( "3)tinyxml2.h Build found" )
+		return matchBuild + " = " + build + ";\n"
+
+	else:
+		return line;
+
+fileProcess( "tinyxml2.h", engineRule )
+
+
+#### Write the dox ####
+
+def doxRule( line ):
+
+	match = "PROJECT_NUMBER"
+
+	if line[0:len( match )] == match:
+		print( "dox project found" )
+		return "PROJECT_NUMBER = " + major + "." + minor + "." + build + "\n"
+
+	else:
+		return line;
+
+fileProcess( "dox", doxRule )
+
+
+#### Write the CMakeLists.txt ####
+
+def cmakeRule1( line ):
+
+	matchVersion = "set(GENERIC_LIB_VERSION"
+
+	if line[0:len(matchVersion)] == matchVersion:
+		print( "1)tinyxml2.h Major found" )
+		return matchVersion + " \"" + major + "." + minor + "." + build + "\")" + "\n"
+
+	else:
+		return line;
+
+fileProcess( "CMakeLists.txt", cmakeRule1 )
+
+def cmakeRule2( line ):
+
+	matchSoversion = "set(GENERIC_LIB_SOVERSION"
+
+	if line[0:len(matchSoversion)] == matchSoversion:
+		print( "1)tinyxml2.h Major found" )
+		return matchSoversion + " \"" + major + "\")" + "\n"
+
+	else:
+		return line;
+
+fileProcess( "CMakeLists.txt", cmakeRule2 )
+
+print( "Release note:" )
+print( '1. Build.   g++ -Wall -DDEBUG tinyxml2.cpp xmltest.cpp -o gccxmltest.exe' )
+print( '2. Commit.  git commit -am"setting the version to ' + versionStr + '"' )
+print( '3. Tag.     git tag ' + versionStr )
+print( '   OR       git tag -a ' + versionStr + ' -m [tag message]' )
+print( 'Remember to "git push" both code and tag. For the tag:' )
+print( 'git push origin [tagname]')
+
+ 

--- a/tinyxml2-3.0.0/tinyxml2.cpp
+++ b/tinyxml2-3.0.0/tinyxml2.cpp
@@ -1,0 +1,2344 @@
+/*
+Original code by Lee Thomason (www.grinninglizard.com)
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+not claim that you wrote the original software. If you use this
+software in a product, an acknowledgment in the product documentation
+would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and
+must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+distribution.
+*/
+
+#include "tinyxml2.h"
+
+#include <new>		// yes, this one new style header, is in the Android SDK.
+#if defined(ANDROID_NDK) || defined(__QNXNTO__)
+#   include <stddef.h>
+#else
+#   include <cstddef>
+#endif
+
+static const char LINE_FEED				= (char)0x0a;			// all line endings are normalized to LF
+static const char LF = LINE_FEED;
+static const char CARRIAGE_RETURN		= (char)0x0d;			// CR gets filtered out
+static const char CR = CARRIAGE_RETURN;
+static const char SINGLE_QUOTE			= '\'';
+static const char DOUBLE_QUOTE			= '\"';
+
+// Bunch of unicode info at:
+//		http://www.unicode.org/faq/utf_bom.html
+//	ef bb bf (Microsoft "lead bytes") - designates UTF-8
+
+static const unsigned char TIXML_UTF_LEAD_0 = 0xefU;
+static const unsigned char TIXML_UTF_LEAD_1 = 0xbbU;
+static const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
+
+namespace tinyxml2
+{
+
+struct Entity {
+    const char* pattern;
+    int length;
+    char value;
+};
+
+static const int NUM_ENTITIES = 5;
+static const Entity entities[NUM_ENTITIES] = {
+    { "quot", 4,	DOUBLE_QUOTE },
+    { "amp", 3,		'&'  },
+    { "apos", 4,	SINGLE_QUOTE },
+    { "lt",	2, 		'<'	 },
+    { "gt",	2,		'>'	 }
+};
+
+
+StrPair::~StrPair()
+{
+    Reset();
+}
+
+
+void StrPair::TransferTo( StrPair* other )
+{
+    if ( this == other ) {
+        return;
+    }
+    // This in effect implements the assignment operator by "moving"
+    // ownership (as in auto_ptr).
+
+    TIXMLASSERT( other->_flags == 0 );
+    TIXMLASSERT( other->_start == 0 );
+    TIXMLASSERT( other->_end == 0 );
+
+    other->Reset();
+
+    other->_flags = _flags;
+    other->_start = _start;
+    other->_end = _end;
+
+    _flags = 0;
+    _start = 0;
+    _end = 0;
+}
+
+void StrPair::Reset()
+{
+    if ( _flags & NEEDS_DELETE ) {
+        delete [] _start;
+    }
+    _flags = 0;
+    _start = 0;
+    _end = 0;
+}
+
+
+void StrPair::SetStr( const char* str, int flags )
+{
+    Reset();
+    size_t len = strlen( str );
+    _start = new char[ len+1 ];
+    memcpy( _start, str, len+1 );
+    _end = _start + len;
+    _flags = flags | NEEDS_DELETE;
+}
+
+
+char* StrPair::ParseText( char* p, const char* endTag, int strFlags )
+{
+    TIXMLASSERT( endTag && *endTag );
+
+    char* start = p;
+    char  endChar = *endTag;
+    size_t length = strlen( endTag );
+
+    // Inner loop of text parsing.
+    while ( *p ) {
+        if ( *p == endChar && strncmp( p, endTag, length ) == 0 ) {
+            Set( start, p, strFlags );
+            return p + length;
+        }
+        ++p;
+    }
+    return 0;
+}
+
+
+char* StrPair::ParseName( char* p )
+{
+    if ( !p || !(*p) ) {
+        return 0;
+    }
+    if ( !XMLUtil::IsNameStartChar( *p ) ) {
+        return 0;
+    }
+
+    char* const start = p;
+    ++p;
+    while ( *p && XMLUtil::IsNameChar( *p ) ) {
+        ++p;
+    }
+
+    Set( start, p, 0 );
+    return p;
+}
+
+
+void StrPair::CollapseWhitespace()
+{
+    // Adjusting _start would cause undefined behavior on delete[]
+    TIXMLASSERT( ( _flags & NEEDS_DELETE ) == 0 );
+    // Trim leading space.
+    _start = XMLUtil::SkipWhiteSpace( _start );
+
+    if ( *_start ) {
+        char* p = _start;	// the read pointer
+        char* q = _start;	// the write pointer
+
+        while( *p ) {
+            if ( XMLUtil::IsWhiteSpace( *p )) {
+                p = XMLUtil::SkipWhiteSpace( p );
+                if ( *p == 0 ) {
+                    break;    // don't write to q; this trims the trailing space.
+                }
+                *q = ' ';
+                ++q;
+            }
+            *q = *p;
+            ++q;
+            ++p;
+        }
+        *q = 0;
+    }
+}
+
+
+const char* StrPair::GetStr()
+{
+    TIXMLASSERT( _start );
+    TIXMLASSERT( _end );
+    if ( _flags & NEEDS_FLUSH ) {
+        *_end = 0;
+        _flags ^= NEEDS_FLUSH;
+
+        if ( _flags ) {
+            char* p = _start;	// the read pointer
+            char* q = _start;	// the write pointer
+
+            while( p < _end ) {
+                if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == CR ) {
+                    // CR-LF pair becomes LF
+                    // CR alone becomes LF
+                    // LF-CR becomes LF
+                    if ( *(p+1) == LF ) {
+                        p += 2;
+                    }
+                    else {
+                        ++p;
+                    }
+                    *q++ = LF;
+                }
+                else if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == LF ) {
+                    if ( *(p+1) == CR ) {
+                        p += 2;
+                    }
+                    else {
+                        ++p;
+                    }
+                    *q++ = LF;
+                }
+                else if ( (_flags & NEEDS_ENTITY_PROCESSING) && *p == '&' ) {
+                    // Entities handled by tinyXML2:
+                    // - special entities in the entity table [in/out]
+                    // - numeric character reference [in]
+                    //   &#20013; or &#x4e2d;
+
+                    if ( *(p+1) == '#' ) {
+                        const int buflen = 10;
+                        char buf[buflen] = { 0 };
+                        int len = 0;
+                        char* adjusted = const_cast<char*>( XMLUtil::GetCharacterRef( p, buf, &len ) );
+                        if ( adjusted == 0 ) {
+                            *q = *p;
+                            ++p;
+                            ++q;
+                        }
+                        else {
+                            TIXMLASSERT( 0 <= len && len <= buflen );
+                            TIXMLASSERT( q + len <= adjusted );
+                            p = adjusted;
+                            memcpy( q, buf, len );
+                            q += len;
+                        }
+                    }
+                    else {
+                        int i=0;
+                        for(; i<NUM_ENTITIES; ++i ) {
+                            const Entity& entity = entities[i];
+                            if ( strncmp( p + 1, entity.pattern, entity.length ) == 0
+                                    && *( p + entity.length + 1 ) == ';' ) {
+                                // Found an entity - convert.
+                                *q = entity.value;
+                                ++q;
+                                p += entity.length + 2;
+                                break;
+                            }
+                        }
+                        if ( i == NUM_ENTITIES ) {
+                            // fixme: treat as error?
+                            ++p;
+                            ++q;
+                        }
+                    }
+                }
+                else {
+                    *q = *p;
+                    ++p;
+                    ++q;
+                }
+            }
+            *q = 0;
+        }
+        // The loop below has plenty going on, and this
+        // is a less useful mode. Break it out.
+        if ( _flags & COLLAPSE_WHITESPACE ) {
+            CollapseWhitespace();
+        }
+        _flags = (_flags & NEEDS_DELETE);
+    }
+    TIXMLASSERT( _start );
+    return _start;
+}
+
+
+
+
+// --------- XMLUtil ----------- //
+
+const char* XMLUtil::ReadBOM( const char* p, bool* bom )
+{
+    TIXMLASSERT( p );
+    TIXMLASSERT( bom );
+    *bom = false;
+    const unsigned char* pu = reinterpret_cast<const unsigned char*>(p);
+    // Check for BOM:
+    if (    *(pu+0) == TIXML_UTF_LEAD_0
+            && *(pu+1) == TIXML_UTF_LEAD_1
+            && *(pu+2) == TIXML_UTF_LEAD_2 ) {
+        *bom = true;
+        p += 3;
+    }
+    TIXMLASSERT( p );
+    return p;
+}
+
+
+void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length )
+{
+    const unsigned long BYTE_MASK = 0xBF;
+    const unsigned long BYTE_MARK = 0x80;
+    const unsigned long FIRST_BYTE_MARK[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
+
+    if (input < 0x80) {
+        *length = 1;
+    }
+    else if ( input < 0x800 ) {
+        *length = 2;
+    }
+    else if ( input < 0x10000 ) {
+        *length = 3;
+    }
+    else if ( input < 0x200000 ) {
+        *length = 4;
+    }
+    else {
+        *length = 0;    // This code won't covert this correctly anyway.
+        return;
+    }
+
+    output += *length;
+
+    // Scary scary fall throughs.
+    switch (*length) {
+        case 4:
+            --output;
+            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+        case 3:
+            --output;
+            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+        case 2:
+            --output;
+            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+        case 1:
+            --output;
+            *output = (char)(input | FIRST_BYTE_MARK[*length]);
+            break;
+        default:
+            TIXMLASSERT( false );
+    }
+}
+
+
+const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
+{
+    // Presume an entity, and pull it out.
+    *length = 0;
+
+    if ( *(p+1) == '#' && *(p+2) ) {
+        unsigned long ucs = 0;
+        TIXMLASSERT( sizeof( ucs ) >= 4 );
+        ptrdiff_t delta = 0;
+        unsigned mult = 1;
+        static const char SEMICOLON = ';';
+
+        if ( *(p+2) == 'x' ) {
+            // Hexadecimal.
+            const char* q = p+3;
+            if ( !(*q) ) {
+                return 0;
+            }
+
+            q = strchr( q, SEMICOLON );
+
+            if ( !q ) {
+                return 0;
+            }
+            TIXMLASSERT( *q == SEMICOLON );
+
+            delta = q-p;
+            --q;
+
+            while ( *q != 'x' ) {
+                unsigned int digit = 0;
+
+                if ( *q >= '0' && *q <= '9' ) {
+                    digit = *q - '0';
+                }
+                else if ( *q >= 'a' && *q <= 'f' ) {
+                    digit = *q - 'a' + 10;
+                }
+                else if ( *q >= 'A' && *q <= 'F' ) {
+                    digit = *q - 'A' + 10;
+                }
+                else {
+                    return 0;
+                }
+                TIXMLASSERT( digit == 0 || mult <= UINT_MAX / digit );
+				TIXMLASSERT( digit >= 0 && digit < 16);
+                const unsigned int digitScaled = mult * digit;
+                TIXMLASSERT( ucs <= ULONG_MAX - digitScaled );
+                ucs += digitScaled;
+                TIXMLASSERT( mult <= UINT_MAX / 16 );
+                mult *= 16;
+                --q;
+            }
+        }
+        else {
+            // Decimal.
+            const char* q = p+2;
+            if ( !(*q) ) {
+                return 0;
+            }
+
+            q = strchr( q, SEMICOLON );
+
+            if ( !q ) {
+                return 0;
+            }
+            TIXMLASSERT( *q == SEMICOLON );
+
+            delta = q-p;
+            --q;
+
+            while ( *q != '#' ) {
+                if ( *q >= '0' && *q <= '9' ) {
+                    const unsigned int digit = *q - '0';
+                    TIXMLASSERT( digit == 0 || mult <= UINT_MAX / digit );
+                    const unsigned int digitScaled = mult * digit;
+                    TIXMLASSERT( ucs <= ULONG_MAX - digitScaled );
+                    ucs += digitScaled;
+                }
+                else {
+                    return 0;
+                }
+                TIXMLASSERT( mult <= UINT_MAX / 10 );
+                mult *= 10;
+                --q;
+            }
+        }
+        // convert the UCS to UTF-8
+        ConvertUTF32ToUTF8( ucs, value, length );
+        return p + delta + 1;
+    }
+    return p+1;
+}
+
+
+void XMLUtil::ToStr( int v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%d", v );
+}
+
+
+void XMLUtil::ToStr( unsigned v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%u", v );
+}
+
+
+void XMLUtil::ToStr( bool v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%d", v ? 1 : 0 );
+}
+
+/*
+	ToStr() of a number is a very tricky topic.
+	https://github.com/leethomason/tinyxml2/issues/106
+*/
+void XMLUtil::ToStr( float v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%.8g", v );
+}
+
+
+void XMLUtil::ToStr( double v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%.17g", v );
+}
+
+
+bool XMLUtil::ToInt( const char* str, int* value )
+{
+    if ( TIXML_SSCANF( str, "%d", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+bool XMLUtil::ToUnsigned( const char* str, unsigned *value )
+{
+    if ( TIXML_SSCANF( str, "%u", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+bool XMLUtil::ToBool( const char* str, bool* value )
+{
+    int ival = 0;
+    if ( ToInt( str, &ival )) {
+        *value = (ival==0) ? false : true;
+        return true;
+    }
+    if ( StringEqual( str, "true" ) ) {
+        *value = true;
+        return true;
+    }
+    else if ( StringEqual( str, "false" ) ) {
+        *value = false;
+        return true;
+    }
+    return false;
+}
+
+
+bool XMLUtil::ToFloat( const char* str, float* value )
+{
+    if ( TIXML_SSCANF( str, "%f", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+bool XMLUtil::ToDouble( const char* str, double* value )
+{
+    if ( TIXML_SSCANF( str, "%lf", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+
+char* XMLDocument::Identify( char* p, XMLNode** node )
+{
+    TIXMLASSERT( node );
+    TIXMLASSERT( p );
+    char* const start = p;
+    p = XMLUtil::SkipWhiteSpace( p );
+    if( !*p ) {
+        *node = 0;
+        TIXMLASSERT( p );
+        return p;
+    }
+
+    // What is this thing?
+	// These strings define the matching patters:
+    static const char* xmlHeader		= { "<?" };
+    static const char* commentHeader	= { "<!--" };
+    static const char* dtdHeader		= { "<!" };
+    static const char* cdataHeader		= { "<![CDATA[" };
+    static const char* elementHeader	= { "<" };	// and a header for everything else; check last.
+
+    static const int xmlHeaderLen		= 2;
+    static const int commentHeaderLen	= 4;
+    static const int dtdHeaderLen		= 2;
+    static const int cdataHeaderLen		= 9;
+    static const int elementHeaderLen	= 1;
+
+    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLUnknown ) );		// use same memory pool
+    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLDeclaration ) );	// use same memory pool
+    XMLNode* returnNode = 0;
+    if ( XMLUtil::StringEqual( p, xmlHeader, xmlHeaderLen ) ) {
+        TIXMLASSERT( sizeof( XMLDeclaration ) == _commentPool.ItemSize() );
+        returnNode = new (_commentPool.Alloc()) XMLDeclaration( this );
+        returnNode->_memPool = &_commentPool;
+        p += xmlHeaderLen;
+    }
+    else if ( XMLUtil::StringEqual( p, commentHeader, commentHeaderLen ) ) {
+        TIXMLASSERT( sizeof( XMLComment ) == _commentPool.ItemSize() );
+        returnNode = new (_commentPool.Alloc()) XMLComment( this );
+        returnNode->_memPool = &_commentPool;
+        p += commentHeaderLen;
+    }
+    else if ( XMLUtil::StringEqual( p, cdataHeader, cdataHeaderLen ) ) {
+        TIXMLASSERT( sizeof( XMLText ) == _textPool.ItemSize() );
+        XMLText* text = new (_textPool.Alloc()) XMLText( this );
+        returnNode = text;
+        returnNode->_memPool = &_textPool;
+        p += cdataHeaderLen;
+        text->SetCData( true );
+    }
+    else if ( XMLUtil::StringEqual( p, dtdHeader, dtdHeaderLen ) ) {
+        TIXMLASSERT( sizeof( XMLUnknown ) == _commentPool.ItemSize() );
+        returnNode = new (_commentPool.Alloc()) XMLUnknown( this );
+        returnNode->_memPool = &_commentPool;
+        p += dtdHeaderLen;
+    }
+    else if ( XMLUtil::StringEqual( p, elementHeader, elementHeaderLen ) ) {
+        TIXMLASSERT( sizeof( XMLElement ) == _elementPool.ItemSize() );
+        returnNode = new (_elementPool.Alloc()) XMLElement( this );
+        returnNode->_memPool = &_elementPool;
+        p += elementHeaderLen;
+    }
+    else {
+        TIXMLASSERT( sizeof( XMLText ) == _textPool.ItemSize() );
+        returnNode = new (_textPool.Alloc()) XMLText( this );
+        returnNode->_memPool = &_textPool;
+        p = start;	// Back it up, all the text counts.
+    }
+
+    TIXMLASSERT( returnNode );
+    TIXMLASSERT( p );
+    *node = returnNode;
+    return p;
+}
+
+
+bool XMLDocument::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    if ( visitor->VisitEnter( *this ) ) {
+        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
+            if ( !node->Accept( visitor ) ) {
+                break;
+            }
+        }
+    }
+    return visitor->VisitExit( *this );
+}
+
+
+// --------- XMLNode ----------- //
+
+XMLNode::XMLNode( XMLDocument* doc ) :
+    _document( doc ),
+    _parent( 0 ),
+    _firstChild( 0 ), _lastChild( 0 ),
+    _prev( 0 ), _next( 0 ),
+    _memPool( 0 )
+{
+}
+
+
+XMLNode::~XMLNode()
+{
+    DeleteChildren();
+    if ( _parent ) {
+        _parent->Unlink( this );
+    }
+}
+
+const char* XMLNode::Value() const 
+{
+    return _value.GetStr();
+}
+
+void XMLNode::SetValue( const char* str, bool staticMem )
+{
+    if ( staticMem ) {
+        _value.SetInternedStr( str );
+    }
+    else {
+        _value.SetStr( str );
+    }
+}
+
+
+void XMLNode::DeleteChildren()
+{
+    while( _firstChild ) {
+        TIXMLASSERT( _firstChild->_document == _document );
+        XMLNode* node = _firstChild;
+        Unlink( node );
+
+        DeleteNode( node );
+    }
+    _firstChild = _lastChild = 0;
+}
+
+
+void XMLNode::Unlink( XMLNode* child )
+{
+    TIXMLASSERT( child );
+    TIXMLASSERT( child->_document == _document );
+    if ( child == _firstChild ) {
+        _firstChild = _firstChild->_next;
+    }
+    if ( child == _lastChild ) {
+        _lastChild = _lastChild->_prev;
+    }
+
+    if ( child->_prev ) {
+        child->_prev->_next = child->_next;
+    }
+    if ( child->_next ) {
+        child->_next->_prev = child->_prev;
+    }
+	child->_parent = 0;
+}
+
+
+void XMLNode::DeleteChild( XMLNode* node )
+{
+    TIXMLASSERT( node );
+    TIXMLASSERT( node->_document == _document );
+    TIXMLASSERT( node->_parent == this );
+    DeleteNode( node );
+}
+
+
+XMLNode* XMLNode::InsertEndChild( XMLNode* addThis )
+{
+    TIXMLASSERT( addThis );
+    if ( addThis->_document != _document ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+    InsertChildPreamble( addThis );
+
+    if ( _lastChild ) {
+        TIXMLASSERT( _firstChild );
+        TIXMLASSERT( _lastChild->_next == 0 );
+        _lastChild->_next = addThis;
+        addThis->_prev = _lastChild;
+        _lastChild = addThis;
+
+        addThis->_next = 0;
+    }
+    else {
+        TIXMLASSERT( _firstChild == 0 );
+        _firstChild = _lastChild = addThis;
+
+        addThis->_prev = 0;
+        addThis->_next = 0;
+    }
+    addThis->_parent = this;
+    return addThis;
+}
+
+
+XMLNode* XMLNode::InsertFirstChild( XMLNode* addThis )
+{
+    TIXMLASSERT( addThis );
+    if ( addThis->_document != _document ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+    InsertChildPreamble( addThis );
+
+    if ( _firstChild ) {
+        TIXMLASSERT( _lastChild );
+        TIXMLASSERT( _firstChild->_prev == 0 );
+
+        _firstChild->_prev = addThis;
+        addThis->_next = _firstChild;
+        _firstChild = addThis;
+
+        addThis->_prev = 0;
+    }
+    else {
+        TIXMLASSERT( _lastChild == 0 );
+        _firstChild = _lastChild = addThis;
+
+        addThis->_prev = 0;
+        addThis->_next = 0;
+    }
+    addThis->_parent = this;
+    return addThis;
+}
+
+
+XMLNode* XMLNode::InsertAfterChild( XMLNode* afterThis, XMLNode* addThis )
+{
+    TIXMLASSERT( addThis );
+    if ( addThis->_document != _document ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+
+    TIXMLASSERT( afterThis );
+
+    if ( afterThis->_parent != this ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+
+    if ( afterThis->_next == 0 ) {
+        // The last node or the only node.
+        return InsertEndChild( addThis );
+    }
+    InsertChildPreamble( addThis );
+    addThis->_prev = afterThis;
+    addThis->_next = afterThis->_next;
+    afterThis->_next->_prev = addThis;
+    afterThis->_next = addThis;
+    addThis->_parent = this;
+    return addThis;
+}
+
+
+
+
+const XMLElement* XMLNode::FirstChildElement( const char* value ) const
+{
+    for( XMLNode* node=_firstChild; node; node=node->_next ) {
+        XMLElement* element = node->ToElement();
+        if ( element ) {
+            if ( !value || XMLUtil::StringEqual( element->Name(), value ) ) {
+                return element;
+            }
+        }
+    }
+    return 0;
+}
+
+
+const XMLElement* XMLNode::LastChildElement( const char* value ) const
+{
+    for( XMLNode* node=_lastChild; node; node=node->_prev ) {
+        XMLElement* element = node->ToElement();
+        if ( element ) {
+            if ( !value || XMLUtil::StringEqual( element->Name(), value ) ) {
+                return element;
+            }
+        }
+    }
+    return 0;
+}
+
+
+const XMLElement* XMLNode::NextSiblingElement( const char* value ) const
+{
+    for( XMLNode* node=this->_next; node; node = node->_next ) {
+        const XMLElement* element = node->ToElement();
+        if ( element
+                && (!value || XMLUtil::StringEqual( value, node->Value() ))) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+const XMLElement* XMLNode::PreviousSiblingElement( const char* value ) const
+{
+    for( XMLNode* node=_prev; node; node = node->_prev ) {
+        const XMLElement* element = node->ToElement();
+        if ( element
+                && (!value || XMLUtil::StringEqual( value, node->Value() ))) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+char* XMLNode::ParseDeep( char* p, StrPair* parentEnd )
+{
+    // This is a recursive method, but thinking about it "at the current level"
+    // it is a pretty simple flat list:
+    //		<foo/>
+    //		<!-- comment -->
+    //
+    // With a special case:
+    //		<foo>
+    //		</foo>
+    //		<!-- comment -->
+    //
+    // Where the closing element (/foo) *must* be the next thing after the opening
+    // element, and the names must match. BUT the tricky bit is that the closing
+    // element will be read by the child.
+    //
+    // 'endTag' is the end tag for this node, it is returned by a call to a child.
+    // 'parentEnd' is the end tag for the parent, which is filled in and returned.
+
+    while( p && *p ) {
+        XMLNode* node = 0;
+
+        p = _document->Identify( p, &node );
+        if ( node == 0 ) {
+            break;
+        }
+
+        StrPair endTag;
+        p = node->ParseDeep( p, &endTag );
+        if ( !p ) {
+            DeleteNode( node );
+            if ( !_document->Error() ) {
+                _document->SetError( XML_ERROR_PARSING, 0, 0 );
+            }
+            break;
+        }
+
+        XMLElement* ele = node->ToElement();
+        if ( ele ) {
+            // We read the end tag. Return it to the parent.
+            if ( ele->ClosingType() == XMLElement::CLOSING ) {
+                if ( parentEnd ) {
+                    ele->_value.TransferTo( parentEnd );
+                }
+                node->_memPool->SetTracked();   // created and then immediately deleted.
+                DeleteNode( node );
+                return p;
+            }
+
+            // Handle an end tag returned to this level.
+            // And handle a bunch of annoying errors.
+            bool mismatch = false;
+            if ( endTag.Empty() ) {
+                if ( ele->ClosingType() == XMLElement::OPEN ) {
+                    mismatch = true;
+                }
+            }
+            else {
+                if ( ele->ClosingType() != XMLElement::OPEN ) {
+                    mismatch = true;
+                }
+                else if ( !XMLUtil::StringEqual( endTag.GetStr(), node->Value() ) ) {
+                    mismatch = true;
+                }
+            }
+            if ( mismatch ) {
+                _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, node->Value(), 0 );
+                DeleteNode( node );
+                break;
+            }
+        }
+        InsertEndChild( node );
+    }
+    return 0;
+}
+
+void XMLNode::DeleteNode( XMLNode* node )
+{
+    if ( node == 0 ) {
+        return;
+    }
+    MemPool* pool = node->_memPool;
+    node->~XMLNode();
+    pool->Free( node );
+}
+
+void XMLNode::InsertChildPreamble( XMLNode* insertThis ) const
+{
+    TIXMLASSERT( insertThis );
+    TIXMLASSERT( insertThis->_document == _document );
+
+    if ( insertThis->_parent )
+        insertThis->_parent->Unlink( insertThis );
+    else
+        insertThis->_memPool->SetTracked();
+}
+
+// --------- XMLText ---------- //
+char* XMLText::ParseDeep( char* p, StrPair* )
+{
+    const char* start = p;
+    if ( this->CData() ) {
+        p = _value.ParseText( p, "]]>", StrPair::NEEDS_NEWLINE_NORMALIZATION );
+        if ( !p ) {
+            _document->SetError( XML_ERROR_PARSING_CDATA, start, 0 );
+        }
+        return p;
+    }
+    else {
+        int flags = _document->ProcessEntities() ? StrPair::TEXT_ELEMENT : StrPair::TEXT_ELEMENT_LEAVE_ENTITIES;
+        if ( _document->WhitespaceMode() == COLLAPSE_WHITESPACE ) {
+            flags |= StrPair::COLLAPSE_WHITESPACE;
+        }
+
+        p = _value.ParseText( p, "<", flags );
+        if ( p && *p ) {
+            return p-1;
+        }
+        if ( !p ) {
+            _document->SetError( XML_ERROR_PARSING_TEXT, start, 0 );
+        }
+    }
+    return 0;
+}
+
+
+XMLNode* XMLText::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLText* text = doc->NewText( Value() );	// fixme: this will always allocate memory. Intern?
+    text->SetCData( this->CData() );
+    return text;
+}
+
+
+bool XMLText::ShallowEqual( const XMLNode* compare ) const
+{
+    const XMLText* text = compare->ToText();
+    return ( text && XMLUtil::StringEqual( text->Value(), Value() ) );
+}
+
+
+bool XMLText::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+
+// --------- XMLComment ---------- //
+
+XMLComment::XMLComment( XMLDocument* doc ) : XMLNode( doc )
+{
+}
+
+
+XMLComment::~XMLComment()
+{
+}
+
+
+char* XMLComment::ParseDeep( char* p, StrPair* )
+{
+    // Comment parses as text.
+    const char* start = p;
+    p = _value.ParseText( p, "-->", StrPair::COMMENT );
+    if ( p == 0 ) {
+        _document->SetError( XML_ERROR_PARSING_COMMENT, start, 0 );
+    }
+    return p;
+}
+
+
+XMLNode* XMLComment::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLComment* comment = doc->NewComment( Value() );	// fixme: this will always allocate memory. Intern?
+    return comment;
+}
+
+
+bool XMLComment::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLComment* comment = compare->ToComment();
+    return ( comment && XMLUtil::StringEqual( comment->Value(), Value() ));
+}
+
+
+bool XMLComment::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+
+// --------- XMLDeclaration ---------- //
+
+XMLDeclaration::XMLDeclaration( XMLDocument* doc ) : XMLNode( doc )
+{
+}
+
+
+XMLDeclaration::~XMLDeclaration()
+{
+    //printf( "~XMLDeclaration\n" );
+}
+
+
+char* XMLDeclaration::ParseDeep( char* p, StrPair* )
+{
+    // Declaration parses as text.
+    const char* start = p;
+    p = _value.ParseText( p, "?>", StrPair::NEEDS_NEWLINE_NORMALIZATION );
+    if ( p == 0 ) {
+        _document->SetError( XML_ERROR_PARSING_DECLARATION, start, 0 );
+    }
+    return p;
+}
+
+
+XMLNode* XMLDeclaration::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLDeclaration* dec = doc->NewDeclaration( Value() );	// fixme: this will always allocate memory. Intern?
+    return dec;
+}
+
+
+bool XMLDeclaration::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLDeclaration* declaration = compare->ToDeclaration();
+    return ( declaration && XMLUtil::StringEqual( declaration->Value(), Value() ));
+}
+
+
+
+bool XMLDeclaration::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+// --------- XMLUnknown ---------- //
+
+XMLUnknown::XMLUnknown( XMLDocument* doc ) : XMLNode( doc )
+{
+}
+
+
+XMLUnknown::~XMLUnknown()
+{
+}
+
+
+char* XMLUnknown::ParseDeep( char* p, StrPair* )
+{
+    // Unknown parses as text.
+    const char* start = p;
+
+    p = _value.ParseText( p, ">", StrPair::NEEDS_NEWLINE_NORMALIZATION );
+    if ( !p ) {
+        _document->SetError( XML_ERROR_PARSING_UNKNOWN, start, 0 );
+    }
+    return p;
+}
+
+
+XMLNode* XMLUnknown::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLUnknown* text = doc->NewUnknown( Value() );	// fixme: this will always allocate memory. Intern?
+    return text;
+}
+
+
+bool XMLUnknown::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLUnknown* unknown = compare->ToUnknown();
+    return ( unknown && XMLUtil::StringEqual( unknown->Value(), Value() ));
+}
+
+
+bool XMLUnknown::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+// --------- XMLAttribute ---------- //
+
+const char* XMLAttribute::Name() const 
+{
+    return _name.GetStr();
+}
+
+const char* XMLAttribute::Value() const 
+{
+    return _value.GetStr();
+}
+
+char* XMLAttribute::ParseDeep( char* p, bool processEntities )
+{
+    // Parse using the name rules: bug fix, was using ParseText before
+    p = _name.ParseName( p );
+    if ( !p || !*p ) {
+        return 0;
+    }
+
+    // Skip white space before =
+    p = XMLUtil::SkipWhiteSpace( p );
+    if ( *p != '=' ) {
+        return 0;
+    }
+
+    ++p;	// move up to opening quote
+    p = XMLUtil::SkipWhiteSpace( p );
+    if ( *p != '\"' && *p != '\'' ) {
+        return 0;
+    }
+
+    char endTag[2] = { *p, 0 };
+    ++p;	// move past opening quote
+
+    p = _value.ParseText( p, endTag, processEntities ? StrPair::ATTRIBUTE_VALUE : StrPair::ATTRIBUTE_VALUE_LEAVE_ENTITIES );
+    return p;
+}
+
+
+void XMLAttribute::SetName( const char* n )
+{
+    _name.SetStr( n );
+}
+
+
+XMLError XMLAttribute::QueryIntValue( int* value ) const
+{
+    if ( XMLUtil::ToInt( Value(), value )) {
+        return XML_NO_ERROR;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryUnsignedValue( unsigned int* value ) const
+{
+    if ( XMLUtil::ToUnsigned( Value(), value )) {
+        return XML_NO_ERROR;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryBoolValue( bool* value ) const
+{
+    if ( XMLUtil::ToBool( Value(), value )) {
+        return XML_NO_ERROR;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryFloatValue( float* value ) const
+{
+    if ( XMLUtil::ToFloat( Value(), value )) {
+        return XML_NO_ERROR;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryDoubleValue( double* value ) const
+{
+    if ( XMLUtil::ToDouble( Value(), value )) {
+        return XML_NO_ERROR;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+void XMLAttribute::SetAttribute( const char* v )
+{
+    _value.SetStr( v );
+}
+
+
+void XMLAttribute::SetAttribute( int v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+
+void XMLAttribute::SetAttribute( unsigned v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+
+void XMLAttribute::SetAttribute( bool v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+void XMLAttribute::SetAttribute( double v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+void XMLAttribute::SetAttribute( float v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+
+// --------- XMLElement ---------- //
+XMLElement::XMLElement( XMLDocument* doc ) : XMLNode( doc ),
+    _closingType( 0 ),
+    _rootAttribute( 0 )
+{
+}
+
+
+XMLElement::~XMLElement()
+{
+    while( _rootAttribute ) {
+        XMLAttribute* next = _rootAttribute->_next;
+        DeleteAttribute( _rootAttribute );
+        _rootAttribute = next;
+    }
+}
+
+
+const XMLAttribute* XMLElement::FindAttribute( const char* name ) const
+{
+    for( XMLAttribute* a = _rootAttribute; a; a = a->_next ) {
+        if ( XMLUtil::StringEqual( a->Name(), name ) ) {
+            return a;
+        }
+    }
+    return 0;
+}
+
+
+const char* XMLElement::Attribute( const char* name, const char* value ) const
+{
+    const XMLAttribute* a = FindAttribute( name );
+    if ( !a ) {
+        return 0;
+    }
+    if ( !value || XMLUtil::StringEqual( a->Value(), value )) {
+        return a->Value();
+    }
+    return 0;
+}
+
+
+const char* XMLElement::GetText() const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        return FirstChild()->Value();
+    }
+    return 0;
+}
+
+
+void	XMLElement::SetText( const char* inText )
+{
+	if ( FirstChild() && FirstChild()->ToText() )
+		FirstChild()->SetValue( inText );
+	else {
+		XMLText*	theText = GetDocument()->NewText( inText );
+		InsertFirstChild( theText );
+	}
+}
+
+
+void XMLElement::SetText( int v ) 
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( unsigned v ) 
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( bool v ) 
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( float v ) 
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( double v ) 
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+XMLError XMLElement::QueryIntText( int* ival ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToInt( t, ival ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryUnsignedText( unsigned* uval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToUnsigned( t, uval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryBoolText( bool* bval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToBool( t, bval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryDoubleText( double* dval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToDouble( t, dval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryFloatText( float* fval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToFloat( t, fval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+
+XMLAttribute* XMLElement::FindOrCreateAttribute( const char* name )
+{
+    XMLAttribute* last = 0;
+    XMLAttribute* attrib = 0;
+    for( attrib = _rootAttribute;
+            attrib;
+            last = attrib, attrib = attrib->_next ) {
+        if ( XMLUtil::StringEqual( attrib->Name(), name ) ) {
+            break;
+        }
+    }
+    if ( !attrib ) {
+        TIXMLASSERT( sizeof( XMLAttribute ) == _document->_attributePool.ItemSize() );
+        attrib = new (_document->_attributePool.Alloc() ) XMLAttribute();
+        attrib->_memPool = &_document->_attributePool;
+        if ( last ) {
+            last->_next = attrib;
+        }
+        else {
+            _rootAttribute = attrib;
+        }
+        attrib->SetName( name );
+        attrib->_memPool->SetTracked(); // always created and linked.
+    }
+    return attrib;
+}
+
+
+void XMLElement::DeleteAttribute( const char* name )
+{
+    XMLAttribute* prev = 0;
+    for( XMLAttribute* a=_rootAttribute; a; a=a->_next ) {
+        if ( XMLUtil::StringEqual( name, a->Name() ) ) {
+            if ( prev ) {
+                prev->_next = a->_next;
+            }
+            else {
+                _rootAttribute = a->_next;
+            }
+            DeleteAttribute( a );
+            break;
+        }
+        prev = a;
+    }
+}
+
+
+char* XMLElement::ParseAttributes( char* p )
+{
+    const char* start = p;
+    XMLAttribute* prevAttribute = 0;
+
+    // Read the attributes.
+    while( p ) {
+        p = XMLUtil::SkipWhiteSpace( p );
+        if ( !(*p) ) {
+            _document->SetError( XML_ERROR_PARSING_ELEMENT, start, Name() );
+            return 0;
+        }
+
+        // attribute.
+        if (XMLUtil::IsNameStartChar( *p ) ) {
+            TIXMLASSERT( sizeof( XMLAttribute ) == _document->_attributePool.ItemSize() );
+            XMLAttribute* attrib = new (_document->_attributePool.Alloc() ) XMLAttribute();
+            attrib->_memPool = &_document->_attributePool;
+			attrib->_memPool->SetTracked();
+
+            p = attrib->ParseDeep( p, _document->ProcessEntities() );
+            if ( !p || Attribute( attrib->Name() ) ) {
+                DeleteAttribute( attrib );
+                _document->SetError( XML_ERROR_PARSING_ATTRIBUTE, start, p );
+                return 0;
+            }
+            // There is a minor bug here: if the attribute in the source xml
+            // document is duplicated, it will not be detected and the
+            // attribute will be doubly added. However, tracking the 'prevAttribute'
+            // avoids re-scanning the attribute list. Preferring performance for
+            // now, may reconsider in the future.
+            if ( prevAttribute ) {
+                prevAttribute->_next = attrib;
+            }
+            else {
+                _rootAttribute = attrib;
+            }
+            prevAttribute = attrib;
+        }
+        // end of the tag
+        else if ( *p == '/' && *(p+1) == '>' ) {
+            _closingType = CLOSED;
+            return p+2;	// done; sealed element.
+        }
+        // end of the tag
+        else if ( *p == '>' ) {
+            ++p;
+            break;
+        }
+        else {
+            _document->SetError( XML_ERROR_PARSING_ELEMENT, start, p );
+            return 0;
+        }
+    }
+    return p;
+}
+
+void XMLElement::DeleteAttribute( XMLAttribute* attribute )
+{
+    if ( attribute == 0 ) {
+        return;
+    }
+    MemPool* pool = attribute->_memPool;
+    attribute->~XMLAttribute();
+    pool->Free( attribute );
+}
+
+//
+//	<ele></ele>
+//	<ele>foo<b>bar</b></ele>
+//
+char* XMLElement::ParseDeep( char* p, StrPair* strPair )
+{
+    // Read the element name.
+    p = XMLUtil::SkipWhiteSpace( p );
+
+    // The closing element is the </element> form. It is
+    // parsed just like a regular element then deleted from
+    // the DOM.
+    if ( *p == '/' ) {
+        _closingType = CLOSING;
+        ++p;
+    }
+
+    p = _value.ParseName( p );
+    if ( _value.Empty() ) {
+        return 0;
+    }
+
+    p = ParseAttributes( p );
+    if ( !p || !*p || _closingType ) {
+        return p;
+    }
+
+    p = XMLNode::ParseDeep( p, strPair );
+    return p;
+}
+
+
+
+XMLNode* XMLElement::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLElement* element = doc->NewElement( Value() );					// fixme: this will always allocate memory. Intern?
+    for( const XMLAttribute* a=FirstAttribute(); a; a=a->Next() ) {
+        element->SetAttribute( a->Name(), a->Value() );					// fixme: this will always allocate memory. Intern?
+    }
+    return element;
+}
+
+
+bool XMLElement::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLElement* other = compare->ToElement();
+    if ( other && XMLUtil::StringEqual( other->Value(), Value() )) {
+
+        const XMLAttribute* a=FirstAttribute();
+        const XMLAttribute* b=other->FirstAttribute();
+
+        while ( a && b ) {
+            if ( !XMLUtil::StringEqual( a->Value(), b->Value() ) ) {
+                return false;
+            }
+            a = a->Next();
+            b = b->Next();
+        }
+        if ( a || b ) {
+            // different count
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+
+bool XMLElement::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    if ( visitor->VisitEnter( *this, _rootAttribute ) ) {
+        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
+            if ( !node->Accept( visitor ) ) {
+                break;
+            }
+        }
+    }
+    return visitor->VisitExit( *this );
+}
+
+
+// --------- XMLDocument ----------- //
+
+// Warning: List must match 'enum XMLError'
+const char* XMLDocument::_errorNames[XML_ERROR_COUNT] = {
+    "XML_SUCCESS",
+    "XML_NO_ATTRIBUTE",
+    "XML_WRONG_ATTRIBUTE_TYPE",
+    "XML_ERROR_FILE_NOT_FOUND",
+    "XML_ERROR_FILE_COULD_NOT_BE_OPENED",
+    "XML_ERROR_FILE_READ_ERROR",
+    "XML_ERROR_ELEMENT_MISMATCH",
+    "XML_ERROR_PARSING_ELEMENT",
+    "XML_ERROR_PARSING_ATTRIBUTE",
+    "XML_ERROR_IDENTIFYING_TAG",
+    "XML_ERROR_PARSING_TEXT",
+    "XML_ERROR_PARSING_CDATA",
+    "XML_ERROR_PARSING_COMMENT",
+    "XML_ERROR_PARSING_DECLARATION",
+    "XML_ERROR_PARSING_UNKNOWN",
+    "XML_ERROR_EMPTY_DOCUMENT",
+    "XML_ERROR_MISMATCHED_ELEMENT",
+    "XML_ERROR_PARSING",
+    "XML_CAN_NOT_CONVERT_TEXT",
+    "XML_NO_TEXT_NODE"
+};
+
+
+XMLDocument::XMLDocument( bool processEntities, Whitespace whitespace ) :
+    XMLNode( 0 ),
+    _writeBOM( false ),
+    _processEntities( processEntities ),
+    _errorID( XML_NO_ERROR ),
+    _whitespace( whitespace ),
+    _errorStr1( 0 ),
+    _errorStr2( 0 ),
+    _charBuffer( 0 )
+{
+    _document = this;	// avoid warning about 'this' in initializer list
+}
+
+
+XMLDocument::~XMLDocument()
+{
+    Clear();
+}
+
+
+void XMLDocument::Clear()
+{
+    DeleteChildren();
+
+#ifdef DEBUG
+    const bool hadError = Error();
+#endif
+    _errorID = XML_NO_ERROR;
+    _errorStr1 = 0;
+    _errorStr2 = 0;
+
+    delete [] _charBuffer;
+    _charBuffer = 0;
+
+#if 0
+    _textPool.Trace( "text" );
+    _elementPool.Trace( "element" );
+    _commentPool.Trace( "comment" );
+    _attributePool.Trace( "attribute" );
+#endif
+    
+#ifdef DEBUG
+    if ( !hadError ) {
+        TIXMLASSERT( _elementPool.CurrentAllocs()   == _elementPool.Untracked() );
+        TIXMLASSERT( _attributePool.CurrentAllocs() == _attributePool.Untracked() );
+        TIXMLASSERT( _textPool.CurrentAllocs()      == _textPool.Untracked() );
+        TIXMLASSERT( _commentPool.CurrentAllocs()   == _commentPool.Untracked() );
+    }
+#endif
+}
+
+
+XMLElement* XMLDocument::NewElement( const char* name )
+{
+    TIXMLASSERT( sizeof( XMLElement ) == _elementPool.ItemSize() );
+    XMLElement* ele = new (_elementPool.Alloc()) XMLElement( this );
+    ele->_memPool = &_elementPool;
+    ele->SetName( name );
+    return ele;
+}
+
+
+XMLComment* XMLDocument::NewComment( const char* str )
+{
+    TIXMLASSERT( sizeof( XMLComment ) == _commentPool.ItemSize() );
+    XMLComment* comment = new (_commentPool.Alloc()) XMLComment( this );
+    comment->_memPool = &_commentPool;
+    comment->SetValue( str );
+    return comment;
+}
+
+
+XMLText* XMLDocument::NewText( const char* str )
+{
+    TIXMLASSERT( sizeof( XMLText ) == _textPool.ItemSize() );
+    XMLText* text = new (_textPool.Alloc()) XMLText( this );
+    text->_memPool = &_textPool;
+    text->SetValue( str );
+    return text;
+}
+
+
+XMLDeclaration* XMLDocument::NewDeclaration( const char* str )
+{
+    TIXMLASSERT( sizeof( XMLDeclaration ) == _commentPool.ItemSize() );
+    XMLDeclaration* dec = new (_commentPool.Alloc()) XMLDeclaration( this );
+    dec->_memPool = &_commentPool;
+    dec->SetValue( str ? str : "xml version=\"1.0\" encoding=\"UTF-8\"" );
+    return dec;
+}
+
+
+XMLUnknown* XMLDocument::NewUnknown( const char* str )
+{
+    TIXMLASSERT( sizeof( XMLUnknown ) == _commentPool.ItemSize() );
+    XMLUnknown* unk = new (_commentPool.Alloc()) XMLUnknown( this );
+    unk->_memPool = &_commentPool;
+    unk->SetValue( str );
+    return unk;
+}
+
+static FILE* callfopen( const char* filepath, const char* mode )
+{
+    TIXMLASSERT( filepath );
+    TIXMLASSERT( mode );
+#if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
+    FILE* fp = 0;
+    errno_t err = fopen_s( &fp, filepath, mode );
+    if ( err ) {
+        return 0;
+    }
+#else
+    FILE* fp = fopen( filepath, mode );
+#endif
+    return fp;
+}
+    
+void XMLDocument::DeleteNode( XMLNode* node )	{
+    TIXMLASSERT( node );
+    TIXMLASSERT(node->_document == this );
+    if (node->_parent) {
+        node->_parent->DeleteChild( node );
+    }
+    else {
+        // Isn't in the tree.
+        // Use the parent delete.
+        // Also, we need to mark it tracked: we 'know'
+        // it was never used.
+        node->_memPool->SetTracked();
+        // Call the static XMLNode version:
+        XMLNode::DeleteNode(node);
+    }
+}
+
+
+XMLError XMLDocument::LoadFile( const char* filename )
+{
+    Clear();
+    FILE* fp = callfopen( filename, "rb" );
+    if ( !fp ) {
+        SetError( XML_ERROR_FILE_NOT_FOUND, filename, 0 );
+        return _errorID;
+    }
+    LoadFile( fp );
+    fclose( fp );
+    return _errorID;
+}
+
+
+XMLError XMLDocument::LoadFile( FILE* fp )
+{
+    Clear();
+
+    fseek( fp, 0, SEEK_SET );
+    if ( fgetc( fp ) == EOF && ferror( fp ) != 0 ) {
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
+    fseek( fp, 0, SEEK_END );
+    const long filelength = ftell( fp );
+    fseek( fp, 0, SEEK_SET );
+    if ( filelength == -1L ) {
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
+    const size_t size = filelength;
+    if ( size == 0 ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return _errorID;
+    }
+
+    _charBuffer = new char[size+1];
+    size_t read = fread( _charBuffer, 1, size, fp );
+    if ( read != size ) {
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
+    _charBuffer[size] = 0;
+
+    Parse();
+    return _errorID;
+}
+
+
+XMLError XMLDocument::SaveFile( const char* filename, bool compact )
+{
+    FILE* fp = callfopen( filename, "w" );
+    if ( !fp ) {
+        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, filename, 0 );
+        return _errorID;
+    }
+    SaveFile(fp, compact);
+    fclose( fp );
+    return _errorID;
+}
+
+
+XMLError XMLDocument::SaveFile( FILE* fp, bool compact )
+{
+    XMLPrinter stream( fp, compact );
+    Print( &stream );
+    return _errorID;
+}
+
+
+XMLError XMLDocument::Parse( const char* p, size_t len )
+{
+    Clear();
+
+    if ( len == 0 || !p || !*p ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return _errorID;
+    }
+    if ( len == (size_t)(-1) ) {
+        len = strlen( p );
+    }
+    _charBuffer = new char[ len+1 ];
+    memcpy( _charBuffer, p, len );
+    _charBuffer[len] = 0;
+
+    Parse();
+    if ( Error() ) {
+        // clean up now essentially dangling memory.
+        // and the parse fail can put objects in the
+        // pools that are dead and inaccessible.
+        DeleteChildren();
+        _elementPool.Clear();
+        _attributePool.Clear();
+        _textPool.Clear();
+        _commentPool.Clear();
+    }
+    return _errorID;
+}
+
+
+void XMLDocument::Print( XMLPrinter* streamer ) const
+{
+    XMLPrinter stdStreamer( stdout );
+    if ( !streamer ) {
+        streamer = &stdStreamer;
+    }
+    Accept( streamer );
+}
+
+
+void XMLDocument::SetError( XMLError error, const char* str1, const char* str2 )
+{
+    TIXMLASSERT( error >= 0 && error < XML_ERROR_COUNT );
+    _errorID = error;
+    _errorStr1 = str1;
+    _errorStr2 = str2;
+}
+
+const char* XMLDocument::ErrorName() const
+{
+	TIXMLASSERT( _errorID >= 0 && _errorID < XML_ERROR_COUNT );
+	return _errorNames[_errorID];
+}
+
+void XMLDocument::PrintError() const
+{
+    if ( Error() ) {
+        static const int LEN = 20;
+        char buf1[LEN] = { 0 };
+        char buf2[LEN] = { 0 };
+
+        if ( _errorStr1 ) {
+            TIXML_SNPRINTF( buf1, LEN, "%s", _errorStr1 );
+        }
+        if ( _errorStr2 ) {
+            TIXML_SNPRINTF( buf2, LEN, "%s", _errorStr2 );
+        }
+
+        printf( "XMLDocument error id=%d '%s' str1=%s str2=%s\n",
+                _errorID, ErrorName(), buf1, buf2 );
+    }
+}
+
+void XMLDocument::Parse()
+{
+    TIXMLASSERT( NoChildren() ); // Clear() must have been called previously
+    TIXMLASSERT( _charBuffer );
+    char* p = _charBuffer;
+    p = XMLUtil::SkipWhiteSpace( p );
+    p = const_cast<char*>( XMLUtil::ReadBOM( p, &_writeBOM ) );
+    if ( !*p ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return;
+    }
+    ParseDeep(p, 0 );
+}
+
+XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
+    _elementJustOpened( false ),
+    _firstElement( true ),
+    _fp( file ),
+    _depth( depth ),
+    _textDepth( -1 ),
+    _processEntities( true ),
+    _compactMode( compact )
+{
+    for( int i=0; i<ENTITY_RANGE; ++i ) {
+        _entityFlag[i] = false;
+        _restrictedEntityFlag[i] = false;
+    }
+    for( int i=0; i<NUM_ENTITIES; ++i ) {
+        const char entityValue = entities[i].value;
+        TIXMLASSERT( 0 <= entityValue && entityValue < ENTITY_RANGE );
+        _entityFlag[ (unsigned char)entityValue ] = true;
+    }
+    _restrictedEntityFlag[(unsigned char)'&'] = true;
+    _restrictedEntityFlag[(unsigned char)'<'] = true;
+    _restrictedEntityFlag[(unsigned char)'>'] = true;	// not required, but consistency is nice
+    _buffer.Push( 0 );
+}
+
+
+void XMLPrinter::Print( const char* format, ... )
+{
+    va_list     va;
+    va_start( va, format );
+
+    if ( _fp ) {
+        vfprintf( _fp, format, va );
+    }
+    else {
+#if defined(_MSC_VER) && (_MSC_VER >= 1400 )
+		#if defined(WINCE)
+		int len = 512;
+		do {
+		    len = len*2;
+		    char* str = new char[len]();
+			len = _vsnprintf(str, len, format, va);
+			delete[] str;
+		}while (len < 0);
+		#else
+        int len = _vscprintf( format, va );
+		#endif
+#else
+        int len = vsnprintf( 0, 0, format, va );
+#endif
+        // Close out and re-start the va-args
+        va_end( va );
+        va_start( va, format );
+        TIXMLASSERT( _buffer.Size() > 0 && _buffer[_buffer.Size() - 1] == 0 );
+        char* p = _buffer.PushArr( len ) - 1;	// back up over the null terminator.
+#if defined(_MSC_VER) && (_MSC_VER >= 1400 )
+		#if defined(WINCE)
+		_vsnprintf( p, len+1, format, va );
+		#else
+		vsnprintf_s( p, len+1, _TRUNCATE, format, va );
+		#endif
+#else
+		vsnprintf( p, len+1, format, va );
+#endif
+    }
+    va_end( va );
+}
+
+
+void XMLPrinter::PrintSpace( int depth )
+{
+    for( int i=0; i<depth; ++i ) {
+        Print( "    " );
+    }
+}
+
+
+void XMLPrinter::PrintString( const char* p, bool restricted )
+{
+    // Look for runs of bytes between entities to print.
+    const char* q = p;
+
+    if ( _processEntities ) {
+        const bool* flag = restricted ? _restrictedEntityFlag : _entityFlag;
+        while ( *q ) {
+            // Remember, char is sometimes signed. (How many times has that bitten me?)
+            if ( *q > 0 && *q < ENTITY_RANGE ) {
+                // Check for entities. If one is found, flush
+                // the stream up until the entity, write the
+                // entity, and keep looking.
+                if ( flag[(unsigned char)(*q)] ) {
+                    while ( p < q ) {
+                        Print( "%c", *p );
+                        ++p;
+                    }
+                    for( int i=0; i<NUM_ENTITIES; ++i ) {
+                        if ( entities[i].value == *q ) {
+                            Print( "&%s;", entities[i].pattern );
+                            break;
+                        }
+                    }
+                    ++p;
+                }
+            }
+            ++q;
+        }
+    }
+    // Flush the remaining string. This will be the entire
+    // string if an entity wasn't found.
+    if ( !_processEntities || (q-p > 0) ) {
+        Print( "%s", p );
+    }
+}
+
+
+void XMLPrinter::PushHeader( bool writeBOM, bool writeDec )
+{
+    if ( writeBOM ) {
+        static const unsigned char bom[] = { TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1, TIXML_UTF_LEAD_2, 0 };
+        Print( "%s", bom );
+    }
+    if ( writeDec ) {
+        PushDeclaration( "xml version=\"1.0\"" );
+    }
+}
+
+
+void XMLPrinter::OpenElement( const char* name, bool compactMode )
+{
+    SealElementIfJustOpened();
+    _stack.Push( name );
+
+    if ( _textDepth < 0 && !_firstElement && !compactMode ) {
+        Print( "\n" );
+    }
+    if ( !compactMode ) {
+        PrintSpace( _depth );
+    }
+
+    Print( "<%s", name );
+    _elementJustOpened = true;
+    _firstElement = false;
+    ++_depth;
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, const char* value )
+{
+    TIXMLASSERT( _elementJustOpened );
+    Print( " %s=\"", name );
+    PrintString( value, false );
+    Print( "\"" );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, int v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, unsigned v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, bool v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, double v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::CloseElement( bool compactMode )
+{
+    --_depth;
+    const char* name = _stack.Pop();
+
+    if ( _elementJustOpened ) {
+        Print( "/>" );
+    }
+    else {
+        if ( _textDepth < 0 && !compactMode) {
+            Print( "\n" );
+            PrintSpace( _depth );
+        }
+        Print( "</%s>", name );
+    }
+
+    if ( _textDepth == _depth ) {
+        _textDepth = -1;
+    }
+    if ( _depth == 0 && !compactMode) {
+        Print( "\n" );
+    }
+    _elementJustOpened = false;
+}
+
+
+void XMLPrinter::SealElementIfJustOpened()
+{
+    if ( !_elementJustOpened ) {
+        return;
+    }
+    _elementJustOpened = false;
+    Print( ">" );
+}
+
+
+void XMLPrinter::PushText( const char* text, bool cdata )
+{
+    _textDepth = _depth-1;
+
+    SealElementIfJustOpened();
+    if ( cdata ) {
+        Print( "<![CDATA[" );
+        Print( "%s", text );
+        Print( "]]>" );
+    }
+    else {
+        PrintString( text, true );
+    }
+}
+
+void XMLPrinter::PushText( int value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( unsigned value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( bool value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( float value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( double value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushComment( const char* comment )
+{
+    SealElementIfJustOpened();
+    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
+        Print( "\n" );
+        PrintSpace( _depth );
+    }
+    _firstElement = false;
+    Print( "<!--%s-->", comment );
+}
+
+
+void XMLPrinter::PushDeclaration( const char* value )
+{
+    SealElementIfJustOpened();
+    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
+        Print( "\n" );
+        PrintSpace( _depth );
+    }
+    _firstElement = false;
+    Print( "<?%s?>", value );
+}
+
+
+void XMLPrinter::PushUnknown( const char* value )
+{
+    SealElementIfJustOpened();
+    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
+        Print( "\n" );
+        PrintSpace( _depth );
+    }
+    _firstElement = false;
+    Print( "<!%s>", value );
+}
+
+
+bool XMLPrinter::VisitEnter( const XMLDocument& doc )
+{
+    _processEntities = doc.ProcessEntities();
+    if ( doc.HasBOM() ) {
+        PushHeader( true, false );
+    }
+    return true;
+}
+
+
+bool XMLPrinter::VisitEnter( const XMLElement& element, const XMLAttribute* attribute )
+{
+	const XMLElement*	parentElem = element.Parent()->ToElement();
+	bool		compactMode = parentElem ? CompactMode(*parentElem) : _compactMode;
+    OpenElement( element.Name(), compactMode );
+    while ( attribute ) {
+        PushAttribute( attribute->Name(), attribute->Value() );
+        attribute = attribute->Next();
+    }
+    return true;
+}
+
+
+bool XMLPrinter::VisitExit( const XMLElement& element )
+{
+    CloseElement( CompactMode(element) );
+    return true;
+}
+
+
+bool XMLPrinter::Visit( const XMLText& text )
+{
+    PushText( text.Value(), text.CData() );
+    return true;
+}
+
+
+bool XMLPrinter::Visit( const XMLComment& comment )
+{
+    PushComment( comment.Value() );
+    return true;
+}
+
+bool XMLPrinter::Visit( const XMLDeclaration& declaration )
+{
+    PushDeclaration( declaration.Value() );
+    return true;
+}
+
+
+bool XMLPrinter::Visit( const XMLUnknown& unknown )
+{
+    PushUnknown( unknown.Value() );
+    return true;
+}
+
+}   // namespace tinyxml2
+

--- a/tinyxml2-3.0.0/tinyxml2.h
+++ b/tinyxml2-3.0.0/tinyxml2.h
@@ -1,0 +1,2130 @@
+/*
+Original code by Lee Thomason (www.grinninglizard.com)
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+not claim that you wrote the original software. If you use this
+software in a product, an acknowledgment in the product documentation
+would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and
+must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+distribution.
+*/
+
+#ifndef TINYXML2_INCLUDED
+#define TINYXML2_INCLUDED
+
+#if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)
+#   include <ctype.h>
+#   include <limits.h>
+#   include <stdio.h>
+#   include <stdlib.h>
+#   include <string.h>
+#   include <stdarg.h>
+#else
+#   include <cctype>
+#   include <climits>
+#   include <cstdio>
+#   include <cstdlib>
+#   include <cstring>
+#   include <cstdarg>
+#endif
+
+/*
+   TODO: intern strings instead of allocation.
+*/
+/*
+	gcc:
+        g++ -Wall -DDEBUG tinyxml2.cpp xmltest.cpp -o gccxmltest.exe
+
+    Formatting, Artistic Style:
+        AStyle.exe --style=1tbs --indent-switches --break-closing-brackets --indent-preprocessor tinyxml2.cpp tinyxml2.h
+*/
+
+#if defined( _DEBUG ) || defined( DEBUG ) || defined (__DEBUG__)
+#   ifndef DEBUG
+#       define DEBUG
+#   endif
+#endif
+
+#ifdef _MSC_VER
+#   pragma warning(push)
+#   pragma warning(disable: 4251)
+#endif
+
+#ifdef _WIN32
+#   ifdef TINYXML2_EXPORT
+#       define TINYXML2_LIB __declspec(dllexport)
+#   elif defined(TINYXML2_IMPORT)
+#       define TINYXML2_LIB __declspec(dllimport)
+#   else
+#       define TINYXML2_LIB
+#   endif
+#else
+#   define TINYXML2_LIB
+#endif
+
+
+#if defined(DEBUG)
+#   if defined(_MSC_VER)
+#       // "(void)0," is for suppressing C4127 warning in "assert(false)", "assert(true)" and the like
+#       define TIXMLASSERT( x )           if ( !((void)0,(x))) { __debugbreak(); } //if ( !(x)) WinDebugBreak()
+#   elif defined (ANDROID_NDK)
+#       include <android/log.h>
+#       define TIXMLASSERT( x )           if ( !(x)) { __android_log_assert( "assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__ ); }
+#   else
+#       include <assert.h>
+#       define TIXMLASSERT                assert
+#   endif
+#   else
+#       define TIXMLASSERT( x )           {}
+#endif
+
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
+// Microsoft visual studio, version 2005 and higher.
+/*int _snprintf_s(
+   char *buffer,
+   size_t sizeOfBuffer,
+   size_t count,
+   const char *format [,
+	  argument] ...
+);*/
+inline int TIXML_SNPRINTF( char* buffer, size_t size, const char* format, ... )
+{
+    va_list va;
+    va_start( va, format );
+    int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
+    va_end( va );
+    return result;
+}
+#define TIXML_SSCANF   sscanf_s
+#elif defined WINCE
+#define TIXML_SNPRINTF _snprintf
+#define TIXML_SSCANF   sscanf
+#else
+// GCC version 3 and higher
+//#warning( "Using sn* functions." )
+#define TIXML_SNPRINTF snprintf
+#define TIXML_SSCANF   sscanf
+#endif
+
+/* Versioning, past 1.0.14:
+	http://semver.org/
+*/
+static const int TIXML2_MAJOR_VERSION = 3;
+static const int TIXML2_MINOR_VERSION = 0;
+static const int TIXML2_PATCH_VERSION = 0;
+
+namespace tinyxml2
+{
+class XMLDocument;
+class XMLElement;
+class XMLAttribute;
+class XMLComment;
+class XMLText;
+class XMLDeclaration;
+class XMLUnknown;
+class XMLPrinter;
+
+/*
+	A class that wraps strings. Normally stores the start and end
+	pointers into the XML file itself, and will apply normalization
+	and entity translation if actually read. Can also store (and memory
+	manage) a traditional char[]
+*/
+class StrPair
+{
+public:
+    enum {
+        NEEDS_ENTITY_PROCESSING			= 0x01,
+        NEEDS_NEWLINE_NORMALIZATION		= 0x02,
+        COLLAPSE_WHITESPACE	                = 0x04,
+
+        TEXT_ELEMENT		            	= NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+        TEXT_ELEMENT_LEAVE_ENTITIES		= NEEDS_NEWLINE_NORMALIZATION,
+        ATTRIBUTE_NAME		            	= 0,
+        ATTRIBUTE_VALUE		            	= NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+        ATTRIBUTE_VALUE_LEAVE_ENTITIES  	= NEEDS_NEWLINE_NORMALIZATION,
+        COMMENT				        = NEEDS_NEWLINE_NORMALIZATION
+    };
+
+    StrPair() : _flags( 0 ), _start( 0 ), _end( 0 ) {}
+    ~StrPair();
+
+    void Set( char* start, char* end, int flags ) {
+        Reset();
+        _start  = start;
+        _end    = end;
+        _flags  = flags | NEEDS_FLUSH;
+    }
+
+    const char* GetStr();
+
+    bool Empty() const {
+        return _start == _end;
+    }
+
+    void SetInternedStr( const char* str ) {
+        Reset();
+        _start = const_cast<char*>(str);
+    }
+
+    void SetStr( const char* str, int flags=0 );
+
+    char* ParseText( char* in, const char* endTag, int strFlags );
+    char* ParseName( char* in );
+
+    void TransferTo( StrPair* other );
+
+private:
+    void Reset();
+    void CollapseWhitespace();
+
+    enum {
+        NEEDS_FLUSH = 0x100,
+        NEEDS_DELETE = 0x200
+    };
+
+    // After parsing, if *_end != 0, it can be set to zero.
+    int     _flags;
+    char*   _start;
+    char*   _end;
+
+    StrPair( const StrPair& other );	// not supported
+    void operator=( StrPair& other );	// not supported, use TransferTo()
+};
+
+
+/*
+	A dynamic array of Plain Old Data. Doesn't support constructors, etc.
+	Has a small initial memory pool, so that low or no usage will not
+	cause a call to new/delete
+*/
+template <class T, int INIT>
+class DynArray
+{
+public:
+    DynArray() {
+        _mem = _pool;
+        _allocated = INIT;
+        _size = 0;
+    }
+
+    ~DynArray() {
+        if ( _mem != _pool ) {
+            delete [] _mem;
+        }
+    }
+
+    void Clear() {
+        _size = 0;
+    }
+
+    void Push( T t ) {
+        TIXMLASSERT( _size < INT_MAX );
+        EnsureCapacity( _size+1 );
+        _mem[_size++] = t;
+    }
+
+    T* PushArr( int count ) {
+        TIXMLASSERT( count >= 0 );
+        TIXMLASSERT( _size <= INT_MAX - count );
+        EnsureCapacity( _size+count );
+        T* ret = &_mem[_size];
+        _size += count;
+        return ret;
+    }
+
+    T Pop() {
+        TIXMLASSERT( _size > 0 );
+        return _mem[--_size];
+    }
+
+    void PopArr( int count ) {
+        TIXMLASSERT( _size >= count );
+        _size -= count;
+    }
+
+    bool Empty() const					{
+        return _size == 0;
+    }
+
+    T& operator[](int i)				{
+        TIXMLASSERT( i>= 0 && i < _size );
+        return _mem[i];
+    }
+
+    const T& operator[](int i) const	{
+        TIXMLASSERT( i>= 0 && i < _size );
+        return _mem[i];
+    }
+
+    const T& PeekTop() const            {
+        TIXMLASSERT( _size > 0 );
+        return _mem[ _size - 1];
+    }
+
+    int Size() const					{
+        TIXMLASSERT( _size >= 0 );
+        return _size;
+    }
+
+    int Capacity() const				{
+        return _allocated;
+    }
+
+    const T* Mem() const				{
+        return _mem;
+    }
+
+    T* Mem()							{
+        return _mem;
+    }
+
+private:
+    DynArray( const DynArray& ); // not supported
+    void operator=( const DynArray& ); // not supported
+
+    void EnsureCapacity( int cap ) {
+        TIXMLASSERT( cap > 0 );
+        if ( cap > _allocated ) {
+            TIXMLASSERT( cap <= INT_MAX / 2 );
+            int newAllocated = cap * 2;
+            T* newMem = new T[newAllocated];
+            memcpy( newMem, _mem, sizeof(T)*_size );	// warning: not using constructors, only works for PODs
+            if ( _mem != _pool ) {
+                delete [] _mem;
+            }
+            _mem = newMem;
+            _allocated = newAllocated;
+        }
+    }
+
+    T*  _mem;
+    T   _pool[INIT];
+    int _allocated;		// objects allocated
+    int _size;			// number objects in use
+};
+
+
+/*
+	Parent virtual class of a pool for fast allocation
+	and deallocation of objects.
+*/
+class MemPool
+{
+public:
+    MemPool() {}
+    virtual ~MemPool() {}
+
+    virtual int ItemSize() const = 0;
+    virtual void* Alloc() = 0;
+    virtual void Free( void* ) = 0;
+    virtual void SetTracked() = 0;
+    virtual void Clear() = 0;
+};
+
+
+/*
+	Template child class to create pools of the correct type.
+*/
+template< int SIZE >
+class MemPoolT : public MemPool
+{
+public:
+    MemPoolT() : _root(0), _currentAllocs(0), _nAllocs(0), _maxAllocs(0), _nUntracked(0)	{}
+    ~MemPoolT() {
+        Clear();
+    }
+    
+    void Clear() {
+        // Delete the blocks.
+        while( !_blockPtrs.Empty()) {
+            Block* b  = _blockPtrs.Pop();
+            delete b;
+        }
+        _root = 0;
+        _currentAllocs = 0;
+        _nAllocs = 0;
+        _maxAllocs = 0;
+        _nUntracked = 0;
+    }
+
+    virtual int ItemSize() const	{
+        return SIZE;
+    }
+    int CurrentAllocs() const		{
+        return _currentAllocs;
+    }
+
+    virtual void* Alloc() {
+        if ( !_root ) {
+            // Need a new block.
+            Block* block = new Block();
+            _blockPtrs.Push( block );
+
+            for( int i=0; i<COUNT-1; ++i ) {
+                block->chunk[i].next = &block->chunk[i+1];
+            }
+            block->chunk[COUNT-1].next = 0;
+            _root = block->chunk;
+        }
+        void* result = _root;
+        _root = _root->next;
+
+        ++_currentAllocs;
+        if ( _currentAllocs > _maxAllocs ) {
+            _maxAllocs = _currentAllocs;
+        }
+        _nAllocs++;
+        _nUntracked++;
+        return result;
+    }
+    
+    virtual void Free( void* mem ) {
+        if ( !mem ) {
+            return;
+        }
+        --_currentAllocs;
+        Chunk* chunk = static_cast<Chunk*>( mem );
+#ifdef DEBUG
+        memset( chunk, 0xfe, sizeof(Chunk) );
+#endif
+        chunk->next = _root;
+        _root = chunk;
+    }
+    void Trace( const char* name ) {
+        printf( "Mempool %s watermark=%d [%dk] current=%d size=%d nAlloc=%d blocks=%d\n",
+                name, _maxAllocs, _maxAllocs*SIZE/1024, _currentAllocs, SIZE, _nAllocs, _blockPtrs.Size() );
+    }
+
+    void SetTracked() {
+        _nUntracked--;
+    }
+
+    int Untracked() const {
+        return _nUntracked;
+    }
+
+	// This number is perf sensitive. 4k seems like a good tradeoff on my machine.
+	// The test file is large, 170k.
+	// Release:		VS2010 gcc(no opt)
+	//		1k:		4000
+	//		2k:		4000
+	//		4k:		3900	21000
+	//		16k:	5200
+	//		32k:	4300
+	//		64k:	4000	21000
+    enum { COUNT = (4*1024)/SIZE }; // Some compilers do not accept to use COUNT in private part if COUNT is private
+
+private:
+    MemPoolT( const MemPoolT& ); // not supported
+    void operator=( const MemPoolT& ); // not supported
+
+    union Chunk {
+        Chunk*  next;
+        char    mem[SIZE];
+    };
+    struct Block {
+        Chunk chunk[COUNT];
+    };
+    DynArray< Block*, 10 > _blockPtrs;
+    Chunk* _root;
+
+    int _currentAllocs;
+    int _nAllocs;
+    int _maxAllocs;
+    int _nUntracked;
+};
+
+
+
+/**
+	Implements the interface to the "Visitor pattern" (see the Accept() method.)
+	If you call the Accept() method, it requires being passed a XMLVisitor
+	class to handle callbacks. For nodes that contain other nodes (Document, Element)
+	you will get called with a VisitEnter/VisitExit pair. Nodes that are always leafs
+	are simply called with Visit().
+
+	If you return 'true' from a Visit method, recursive parsing will continue. If you return
+	false, <b>no children of this node or its siblings</b> will be visited.
+
+	All flavors of Visit methods have a default implementation that returns 'true' (continue
+	visiting). You need to only override methods that are interesting to you.
+
+	Generally Accept() is called on the XMLDocument, although all nodes support visiting.
+
+	You should never change the document from a callback.
+
+	@sa XMLNode::Accept()
+*/
+class TINYXML2_LIB XMLVisitor
+{
+public:
+    virtual ~XMLVisitor() {}
+
+    /// Visit a document.
+    virtual bool VisitEnter( const XMLDocument& /*doc*/ )			{
+        return true;
+    }
+    /// Visit a document.
+    virtual bool VisitExit( const XMLDocument& /*doc*/ )			{
+        return true;
+    }
+
+    /// Visit an element.
+    virtual bool VisitEnter( const XMLElement& /*element*/, const XMLAttribute* /*firstAttribute*/ )	{
+        return true;
+    }
+    /// Visit an element.
+    virtual bool VisitExit( const XMLElement& /*element*/ )			{
+        return true;
+    }
+
+    /// Visit a declaration.
+    virtual bool Visit( const XMLDeclaration& /*declaration*/ )		{
+        return true;
+    }
+    /// Visit a text node.
+    virtual bool Visit( const XMLText& /*text*/ )					{
+        return true;
+    }
+    /// Visit a comment node.
+    virtual bool Visit( const XMLComment& /*comment*/ )				{
+        return true;
+    }
+    /// Visit an unknown node.
+    virtual bool Visit( const XMLUnknown& /*unknown*/ )				{
+        return true;
+    }
+};
+
+// WARNING: must match XMLDocument::_errorNames[]
+enum XMLError {
+    XML_SUCCESS = 0,
+    XML_NO_ERROR = 0,
+    XML_NO_ATTRIBUTE,
+    XML_WRONG_ATTRIBUTE_TYPE,
+    XML_ERROR_FILE_NOT_FOUND,
+    XML_ERROR_FILE_COULD_NOT_BE_OPENED,
+    XML_ERROR_FILE_READ_ERROR,
+    XML_ERROR_ELEMENT_MISMATCH,
+    XML_ERROR_PARSING_ELEMENT,
+    XML_ERROR_PARSING_ATTRIBUTE,
+    XML_ERROR_IDENTIFYING_TAG,
+    XML_ERROR_PARSING_TEXT,
+    XML_ERROR_PARSING_CDATA,
+    XML_ERROR_PARSING_COMMENT,
+    XML_ERROR_PARSING_DECLARATION,
+    XML_ERROR_PARSING_UNKNOWN,
+    XML_ERROR_EMPTY_DOCUMENT,
+    XML_ERROR_MISMATCHED_ELEMENT,
+    XML_ERROR_PARSING,
+    XML_CAN_NOT_CONVERT_TEXT,
+    XML_NO_TEXT_NODE,
+
+	XML_ERROR_COUNT
+};
+
+
+/*
+	Utility functionality.
+*/
+class XMLUtil
+{
+public:
+    static const char* SkipWhiteSpace( const char* p )	{
+        TIXMLASSERT( p );
+        while( IsWhiteSpace(*p) ) {
+            ++p;
+        }
+        TIXMLASSERT( p );
+        return p;
+    }
+    static char* SkipWhiteSpace( char* p )				{
+        return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p) ) );
+    }
+
+    // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
+    // correct, but simple, and usually works.
+    static bool IsWhiteSpace( char p )					{
+        return !IsUTF8Continuation(p) && isspace( static_cast<unsigned char>(p) );
+    }
+    
+    inline static bool IsNameStartChar( unsigned char ch ) {
+        if ( ch >= 128 ) {
+            // This is a heuristic guess in attempt to not implement Unicode-aware isalpha()
+            return true;
+        }
+        if ( isalpha( ch ) ) {
+            return true;
+        }
+        return ch == ':' || ch == '_';
+    }
+    
+    inline static bool IsNameChar( unsigned char ch ) {
+        return IsNameStartChar( ch )
+               || isdigit( ch )
+               || ch == '.'
+               || ch == '-';
+    }
+
+    inline static bool StringEqual( const char* p, const char* q, int nChar=INT_MAX )  {
+        if ( p == q ) {
+            return true;
+        }
+        int n = 0;
+        while( *p && *q && *p == *q && n<nChar ) {
+            ++p;
+            ++q;
+            ++n;
+        }
+        if ( (n == nChar) || ( *p == 0 && *q == 0 ) ) {
+            return true;
+        }
+        return false;
+    }
+    
+    inline static bool IsUTF8Continuation( const char p ) {
+        return ( p & 0x80 ) != 0;
+    }
+
+    static const char* ReadBOM( const char* p, bool* hasBOM );
+    // p is the starting location,
+    // the UTF-8 value of the entity will be placed in value, and length filled in.
+    static const char* GetCharacterRef( const char* p, char* value, int* length );
+    static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
+
+    // converts primitive types to strings
+    static void ToStr( int v, char* buffer, int bufferSize );
+    static void ToStr( unsigned v, char* buffer, int bufferSize );
+    static void ToStr( bool v, char* buffer, int bufferSize );
+    static void ToStr( float v, char* buffer, int bufferSize );
+    static void ToStr( double v, char* buffer, int bufferSize );
+
+    // converts strings to primitive types
+    static bool	ToInt( const char* str, int* value );
+    static bool ToUnsigned( const char* str, unsigned* value );
+    static bool	ToBool( const char* str, bool* value );
+    static bool	ToFloat( const char* str, float* value );
+    static bool ToDouble( const char* str, double* value );
+};
+
+
+/** XMLNode is a base class for every object that is in the
+	XML Document Object Model (DOM), except XMLAttributes.
+	Nodes have siblings, a parent, and children which can
+	be navigated. A node is always in a XMLDocument.
+	The type of a XMLNode can be queried, and it can
+	be cast to its more defined type.
+
+	A XMLDocument allocates memory for all its Nodes.
+	When the XMLDocument gets deleted, all its Nodes
+	will also be deleted.
+
+	@verbatim
+	A Document can contain:	Element	(container or leaf)
+							Comment (leaf)
+							Unknown (leaf)
+							Declaration( leaf )
+
+	An Element can contain:	Element (container or leaf)
+							Text	(leaf)
+							Attributes (not on tree)
+							Comment (leaf)
+							Unknown (leaf)
+
+	@endverbatim
+*/
+class TINYXML2_LIB XMLNode
+{
+    friend class XMLDocument;
+    friend class XMLElement;
+public:
+
+    /// Get the XMLDocument that owns this XMLNode.
+    const XMLDocument* GetDocument() const	{
+        return _document;
+    }
+    /// Get the XMLDocument that owns this XMLNode.
+    XMLDocument* GetDocument()				{
+        return _document;
+    }
+
+    /// Safely cast to an Element, or null.
+    virtual XMLElement*		ToElement()		{
+        return 0;
+    }
+    /// Safely cast to Text, or null.
+    virtual XMLText*		ToText()		{
+        return 0;
+    }
+    /// Safely cast to a Comment, or null.
+    virtual XMLComment*		ToComment()		{
+        return 0;
+    }
+    /// Safely cast to a Document, or null.
+    virtual XMLDocument*	ToDocument()	{
+        return 0;
+    }
+    /// Safely cast to a Declaration, or null.
+    virtual XMLDeclaration*	ToDeclaration()	{
+        return 0;
+    }
+    /// Safely cast to an Unknown, or null.
+    virtual XMLUnknown*		ToUnknown()		{
+        return 0;
+    }
+
+    virtual const XMLElement*		ToElement() const		{
+        return 0;
+    }
+    virtual const XMLText*			ToText() const			{
+        return 0;
+    }
+    virtual const XMLComment*		ToComment() const		{
+        return 0;
+    }
+    virtual const XMLDocument*		ToDocument() const		{
+        return 0;
+    }
+    virtual const XMLDeclaration*	ToDeclaration() const	{
+        return 0;
+    }
+    virtual const XMLUnknown*		ToUnknown() const		{
+        return 0;
+    }
+
+    /** The meaning of 'value' changes for the specific type.
+    	@verbatim
+    	Document:	empty
+    	Element:	name of the element
+    	Comment:	the comment text
+    	Unknown:	the tag contents
+    	Text:		the text string
+    	@endverbatim
+    */
+    const char* Value() const;
+
+    /** Set the Value of an XML node.
+    	@sa Value()
+    */
+    void SetValue( const char* val, bool staticMem=false );
+
+    /// Get the parent of this node on the DOM.
+    const XMLNode*	Parent() const			{
+        return _parent;
+    }
+
+    XMLNode* Parent()						{
+        return _parent;
+    }
+
+    /// Returns true if this node has no children.
+    bool NoChildren() const					{
+        return !_firstChild;
+    }
+
+    /// Get the first child node, or null if none exists.
+    const XMLNode*  FirstChild() const		{
+        return _firstChild;
+    }
+
+    XMLNode*		FirstChild()			{
+        return _firstChild;
+    }
+
+    /** Get the first child element, or optionally the first child
+        element with the specified name.
+    */
+    const XMLElement* FirstChildElement( const char* value=0 ) const;
+
+    XMLElement* FirstChildElement( const char* value=0 )	{
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->FirstChildElement( value ));
+    }
+
+    /// Get the last child node, or null if none exists.
+    const XMLNode*	LastChild() const						{
+        return _lastChild;
+    }
+
+    XMLNode*		LastChild()								{
+        return const_cast<XMLNode*>(const_cast<const XMLNode*>(this)->LastChild() );
+    }
+
+    /** Get the last child element or optionally the last child
+        element with the specified name.
+    */
+    const XMLElement* LastChildElement( const char* value=0 ) const;
+
+    XMLElement* LastChildElement( const char* value=0 )	{
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->LastChildElement(value) );
+    }
+
+    /// Get the previous (left) sibling node of this node.
+    const XMLNode*	PreviousSibling() const					{
+        return _prev;
+    }
+
+    XMLNode*	PreviousSibling()							{
+        return _prev;
+    }
+
+    /// Get the previous (left) sibling element of this node, with an optionally supplied name.
+    const XMLElement*	PreviousSiblingElement( const char* value=0 ) const ;
+
+    XMLElement*	PreviousSiblingElement( const char* value=0 ) {
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->PreviousSiblingElement( value ) );
+    }
+
+    /// Get the next (right) sibling node of this node.
+    const XMLNode*	NextSibling() const						{
+        return _next;
+    }
+
+    XMLNode*	NextSibling()								{
+        return _next;
+    }
+
+    /// Get the next (right) sibling element of this node, with an optionally supplied name.
+    const XMLElement*	NextSiblingElement( const char* value=0 ) const;
+
+    XMLElement*	NextSiblingElement( const char* value=0 )	{
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->NextSiblingElement( value ) );
+    }
+
+    /**
+    	Add a child node as the last (right) child.
+		If the child node is already part of the document,
+		it is moved from its old location to the new location.
+		Returns the addThis argument or 0 if the node does not
+		belong to the same document.
+    */
+    XMLNode* InsertEndChild( XMLNode* addThis );
+
+    XMLNode* LinkEndChild( XMLNode* addThis )	{
+        return InsertEndChild( addThis );
+    }
+    /**
+    	Add a child node as the first (left) child.
+		If the child node is already part of the document,
+		it is moved from its old location to the new location.
+		Returns the addThis argument or 0 if the node does not
+		belong to the same document.
+    */
+    XMLNode* InsertFirstChild( XMLNode* addThis );
+    /**
+    	Add a node after the specified child node.
+		If the child node is already part of the document,
+		it is moved from its old location to the new location.
+		Returns the addThis argument or 0 if the afterThis node
+		is not a child of this node, or if the node does not
+		belong to the same document.
+    */
+    XMLNode* InsertAfterChild( XMLNode* afterThis, XMLNode* addThis );
+
+    /**
+    	Delete all the children of this node.
+    */
+    void DeleteChildren();
+
+    /**
+    	Delete a child of this node.
+    */
+    void DeleteChild( XMLNode* node );
+
+    /**
+    	Make a copy of this node, but not its children.
+    	You may pass in a Document pointer that will be
+    	the owner of the new Node. If the 'document' is
+    	null, then the node returned will be allocated
+    	from the current Document. (this->GetDocument())
+
+    	Note: if called on a XMLDocument, this will return null.
+    */
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const = 0;
+
+    /**
+    	Test if 2 nodes are the same, but don't test children.
+    	The 2 nodes do not need to be in the same Document.
+
+    	Note: if called on a XMLDocument, this will return false.
+    */
+    virtual bool ShallowEqual( const XMLNode* compare ) const = 0;
+
+    /** Accept a hierarchical visit of the nodes in the TinyXML-2 DOM. Every node in the
+    	XML tree will be conditionally visited and the host will be called back
+    	via the XMLVisitor interface.
+
+    	This is essentially a SAX interface for TinyXML-2. (Note however it doesn't re-parse
+    	the XML for the callbacks, so the performance of TinyXML-2 is unchanged by using this
+    	interface versus any other.)
+
+    	The interface has been based on ideas from:
+
+    	- http://www.saxproject.org/
+    	- http://c2.com/cgi/wiki?HierarchicalVisitorPattern
+
+    	Which are both good references for "visiting".
+
+    	An example of using Accept():
+    	@verbatim
+    	XMLPrinter printer;
+    	tinyxmlDoc.Accept( &printer );
+    	const char* xmlcstr = printer.CStr();
+    	@endverbatim
+    */
+    virtual bool Accept( XMLVisitor* visitor ) const = 0;
+
+    // internal
+    virtual char* ParseDeep( char*, StrPair* );
+
+protected:
+    XMLNode( XMLDocument* );
+    virtual ~XMLNode();
+
+    XMLDocument*	_document;
+    XMLNode*		_parent;
+    mutable StrPair	_value;
+
+    XMLNode*		_firstChild;
+    XMLNode*		_lastChild;
+
+    XMLNode*		_prev;
+    XMLNode*		_next;
+
+private:
+    MemPool*		_memPool;
+    void Unlink( XMLNode* child );
+    static void DeleteNode( XMLNode* node );
+    void InsertChildPreamble( XMLNode* insertThis ) const;
+
+    XMLNode( const XMLNode& );	// not supported
+    XMLNode& operator=( const XMLNode& );	// not supported
+};
+
+
+/** XML text.
+
+	Note that a text node can have child element nodes, for example:
+	@verbatim
+	<root>This is <b>bold</b></root>
+	@endverbatim
+
+	A text node can have 2 ways to output the next. "normal" output
+	and CDATA. It will default to the mode it was parsed from the XML file and
+	you generally want to leave it alone, but you can change the output mode with
+	SetCData() and query it with CData().
+*/
+class TINYXML2_LIB XMLText : public XMLNode
+{
+    friend class XMLBase;
+    friend class XMLDocument;
+public:
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    virtual XMLText* ToText()			{
+        return this;
+    }
+    virtual const XMLText* ToText() const	{
+        return this;
+    }
+
+    /// Declare whether this should be CDATA or standard text.
+    void SetCData( bool isCData )			{
+        _isCData = isCData;
+    }
+    /// Returns true if this is a CDATA text element.
+    bool CData() const						{
+        return _isCData;
+    }
+
+    char* ParseDeep( char*, StrPair* endTag );
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    XMLText( XMLDocument* doc )	: XMLNode( doc ), _isCData( false )	{}
+    virtual ~XMLText()												{}
+
+private:
+    bool _isCData;
+
+    XMLText( const XMLText& );	// not supported
+    XMLText& operator=( const XMLText& );	// not supported
+};
+
+
+/** An XML Comment. */
+class TINYXML2_LIB XMLComment : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLComment*	ToComment()					{
+        return this;
+    }
+    virtual const XMLComment* ToComment() const		{
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    char* ParseDeep( char*, StrPair* endTag );
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    XMLComment( XMLDocument* doc );
+    virtual ~XMLComment();
+
+private:
+    XMLComment( const XMLComment& );	// not supported
+    XMLComment& operator=( const XMLComment& );	// not supported
+};
+
+
+/** In correct XML the declaration is the first entry in the file.
+	@verbatim
+		<?xml version="1.0" standalone="yes"?>
+	@endverbatim
+
+	TinyXML-2 will happily read or write files without a declaration,
+	however.
+
+	The text of the declaration isn't interpreted. It is parsed
+	and written as a string.
+*/
+class TINYXML2_LIB XMLDeclaration : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLDeclaration*	ToDeclaration()					{
+        return this;
+    }
+    virtual const XMLDeclaration* ToDeclaration() const		{
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    char* ParseDeep( char*, StrPair* endTag );
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    XMLDeclaration( XMLDocument* doc );
+    virtual ~XMLDeclaration();
+
+private:
+    XMLDeclaration( const XMLDeclaration& );	// not supported
+    XMLDeclaration& operator=( const XMLDeclaration& );	// not supported
+};
+
+
+/** Any tag that TinyXML-2 doesn't recognize is saved as an
+	unknown. It is a tag of text, but should not be modified.
+	It will be written back to the XML, unchanged, when the file
+	is saved.
+
+	DTD tags get thrown into XMLUnknowns.
+*/
+class TINYXML2_LIB XMLUnknown : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLUnknown*	ToUnknown()					{
+        return this;
+    }
+    virtual const XMLUnknown* ToUnknown() const		{
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    char* ParseDeep( char*, StrPair* endTag );
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    XMLUnknown( XMLDocument* doc );
+    virtual ~XMLUnknown();
+
+private:
+    XMLUnknown( const XMLUnknown& );	// not supported
+    XMLUnknown& operator=( const XMLUnknown& );	// not supported
+};
+
+
+
+/** An attribute is a name-value pair. Elements have an arbitrary
+	number of attributes, each with a unique name.
+
+	@note The attributes are not XMLNodes. You may only query the
+	Next() attribute in a list.
+*/
+class TINYXML2_LIB XMLAttribute
+{
+    friend class XMLElement;
+public:
+    /// The name of the attribute.
+    const char* Name() const;
+
+    /// The value of the attribute.
+    const char* Value() const;
+
+    /// The next attribute in the list.
+    const XMLAttribute* Next() const {
+        return _next;
+    }
+
+    /** IntValue interprets the attribute as an integer, and returns the value.
+        If the value isn't an integer, 0 will be returned. There is no error checking;
+    	use QueryIntValue() if you need error checking.
+    */
+    int		 IntValue() const				{
+        int i=0;
+        QueryIntValue( &i );
+        return i;
+    }
+    /// Query as an unsigned integer. See IntValue()
+    unsigned UnsignedValue() const			{
+        unsigned i=0;
+        QueryUnsignedValue( &i );
+        return i;
+    }
+    /// Query as a boolean. See IntValue()
+    bool	 BoolValue() const				{
+        bool b=false;
+        QueryBoolValue( &b );
+        return b;
+    }
+    /// Query as a double. See IntValue()
+    double 	 DoubleValue() const			{
+        double d=0;
+        QueryDoubleValue( &d );
+        return d;
+    }
+    /// Query as a float. See IntValue()
+    float	 FloatValue() const				{
+        float f=0;
+        QueryFloatValue( &f );
+        return f;
+    }
+
+    /** QueryIntValue interprets the attribute as an integer, and returns the value
+    	in the provided parameter. The function will return XML_NO_ERROR on success,
+    	and XML_WRONG_ATTRIBUTE_TYPE if the conversion is not successful.
+    */
+    XMLError QueryIntValue( int* value ) const;
+    /// See QueryIntValue
+    XMLError QueryUnsignedValue( unsigned int* value ) const;
+    /// See QueryIntValue
+    XMLError QueryBoolValue( bool* value ) const;
+    /// See QueryIntValue
+    XMLError QueryDoubleValue( double* value ) const;
+    /// See QueryIntValue
+    XMLError QueryFloatValue( float* value ) const;
+
+    /// Set the attribute to a string value.
+    void SetAttribute( const char* value );
+    /// Set the attribute to value.
+    void SetAttribute( int value );
+    /// Set the attribute to value.
+    void SetAttribute( unsigned value );
+    /// Set the attribute to value.
+    void SetAttribute( bool value );
+    /// Set the attribute to value.
+    void SetAttribute( double value );
+    /// Set the attribute to value.
+    void SetAttribute( float value );
+
+private:
+    enum { BUF_SIZE = 200 };
+
+    XMLAttribute() : _next( 0 ), _memPool( 0 ) {}
+    virtual ~XMLAttribute()	{}
+
+    XMLAttribute( const XMLAttribute& );	// not supported
+    void operator=( const XMLAttribute& );	// not supported
+    void SetName( const char* name );
+
+    char* ParseDeep( char* p, bool processEntities );
+
+    mutable StrPair _name;
+    mutable StrPair _value;
+    XMLAttribute*   _next;
+    MemPool*        _memPool;
+};
+
+
+/** The element is a container class. It has a value, the element name,
+	and can contain other elements, text, comments, and unknowns.
+	Elements also contain an arbitrary number of attributes.
+*/
+class TINYXML2_LIB XMLElement : public XMLNode
+{
+    friend class XMLBase;
+    friend class XMLDocument;
+public:
+    /// Get the name of an element (which is the Value() of the node.)
+    const char* Name() const		{
+        return Value();
+    }
+    /// Set the name of the element.
+    void SetName( const char* str, bool staticMem=false )	{
+        SetValue( str, staticMem );
+    }
+
+    virtual XMLElement* ToElement()				{
+        return this;
+    }
+    virtual const XMLElement* ToElement() const {
+        return this;
+    }
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    /** Given an attribute name, Attribute() returns the value
+    	for the attribute of that name, or null if none
+    	exists. For example:
+
+    	@verbatim
+    	const char* value = ele->Attribute( "foo" );
+    	@endverbatim
+
+    	The 'value' parameter is normally null. However, if specified,
+    	the attribute will only be returned if the 'name' and 'value'
+    	match. This allow you to write code:
+
+    	@verbatim
+    	if ( ele->Attribute( "foo", "bar" ) ) callFooIsBar();
+    	@endverbatim
+
+    	rather than:
+    	@verbatim
+    	if ( ele->Attribute( "foo" ) ) {
+    		if ( strcmp( ele->Attribute( "foo" ), "bar" ) == 0 ) callFooIsBar();
+    	}
+    	@endverbatim
+    */
+    const char* Attribute( const char* name, const char* value=0 ) const;
+
+    /** Given an attribute name, IntAttribute() returns the value
+    	of the attribute interpreted as an integer. 0 will be
+    	returned if there is an error. For a method with error
+    	checking, see QueryIntAttribute()
+    */
+    int		 IntAttribute( const char* name ) const		{
+        int i=0;
+        QueryIntAttribute( name, &i );
+        return i;
+    }
+    /// See IntAttribute()
+    unsigned UnsignedAttribute( const char* name ) const {
+        unsigned i=0;
+        QueryUnsignedAttribute( name, &i );
+        return i;
+    }
+    /// See IntAttribute()
+    bool	 BoolAttribute( const char* name ) const	{
+        bool b=false;
+        QueryBoolAttribute( name, &b );
+        return b;
+    }
+    /// See IntAttribute()
+    double 	 DoubleAttribute( const char* name ) const	{
+        double d=0;
+        QueryDoubleAttribute( name, &d );
+        return d;
+    }
+    /// See IntAttribute()
+    float	 FloatAttribute( const char* name ) const	{
+        float f=0;
+        QueryFloatAttribute( name, &f );
+        return f;
+    }
+
+    /** Given an attribute name, QueryIntAttribute() returns
+    	XML_NO_ERROR, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
+    	doesn't exist. If successful, the result of the conversion
+    	will be written to 'value'. If not successful, nothing will
+    	be written to 'value'. This allows you to provide default
+    	value:
+
+    	@verbatim
+    	int value = 10;
+    	QueryIntAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
+    	@endverbatim
+    */
+    XMLError QueryIntAttribute( const char* name, int* value ) const				{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryIntValue( value );
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryUnsignedAttribute( const char* name, unsigned int* value ) const	{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryUnsignedValue( value );
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryBoolAttribute( const char* name, bool* value ) const				{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryBoolValue( value );
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryDoubleAttribute( const char* name, double* value ) const			{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryDoubleValue( value );
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryFloatAttribute( const char* name, float* value ) const			{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryFloatValue( value );
+    }
+
+	
+    /** Given an attribute name, QueryAttribute() returns
+    	XML_NO_ERROR, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
+    	doesn't exist. It is overloaded for the primitive types,
+		and is a generally more convenient replacement of
+		QueryIntAttribute() and related functions.
+		
+		If successful, the result of the conversion
+    	will be written to 'value'. If not successful, nothing will
+    	be written to 'value'. This allows you to provide default
+    	value:
+
+    	@verbatim
+    	int value = 10;
+    	QueryAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
+    	@endverbatim
+    */
+	int QueryAttribute( const char* name, int* value ) const {
+		return QueryIntAttribute( name, value );
+	}
+
+	int QueryAttribute( const char* name, unsigned int* value ) const {
+		return QueryUnsignedAttribute( name, value );
+	}
+
+	int QueryAttribute( const char* name, bool* value ) const {
+		return QueryBoolAttribute( name, value );
+	}
+
+	int QueryAttribute( const char* name, double* value ) const {
+		return QueryDoubleAttribute( name, value );
+	}
+
+	int QueryAttribute( const char* name, float* value ) const {
+		return QueryFloatAttribute( name, value );
+	}
+
+	/// Sets the named attribute to value.
+    void SetAttribute( const char* name, const char* value )	{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, int value )			{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, unsigned value )		{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, bool value )			{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, double value )		{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, float value )		{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+
+    /**
+    	Delete an attribute.
+    */
+    void DeleteAttribute( const char* name );
+
+    /// Return the first attribute in the list.
+    const XMLAttribute* FirstAttribute() const {
+        return _rootAttribute;
+    }
+    /// Query a specific attribute in the list.
+    const XMLAttribute* FindAttribute( const char* name ) const;
+
+    /** Convenience function for easy access to the text inside an element. Although easy
+    	and concise, GetText() is limited compared to getting the XMLText child
+    	and accessing it directly.
+
+    	If the first child of 'this' is a XMLText, the GetText()
+    	returns the character string of the Text node, else null is returned.
+
+    	This is a convenient method for getting the text of simple contained text:
+    	@verbatim
+    	<foo>This is text</foo>
+    		const char* str = fooElement->GetText();
+    	@endverbatim
+
+    	'str' will be a pointer to "This is text".
+
+    	Note that this function can be misleading. If the element foo was created from
+    	this XML:
+    	@verbatim
+    		<foo><b>This is text</b></foo>
+    	@endverbatim
+
+    	then the value of str would be null. The first child node isn't a text node, it is
+    	another element. From this XML:
+    	@verbatim
+    		<foo>This is <b>text</b></foo>
+    	@endverbatim
+    	GetText() will return "This is ".
+    */
+    const char* GetText() const;
+
+    /** Convenience function for easy access to the text inside an element. Although easy
+    	and concise, SetText() is limited compared to creating an XMLText child
+    	and mutating it directly.
+
+    	If the first child of 'this' is a XMLText, SetText() sets its value to
+		the given string, otherwise it will create a first child that is an XMLText.
+
+    	This is a convenient method for setting the text of simple contained text:
+    	@verbatim
+    	<foo>This is text</foo>
+    		fooElement->SetText( "Hullaballoo!" );
+     	<foo>Hullaballoo!</foo>
+		@endverbatim
+
+    	Note that this function can be misleading. If the element foo was created from
+    	this XML:
+    	@verbatim
+    		<foo><b>This is text</b></foo>
+    	@endverbatim
+
+    	then it will not change "This is text", but rather prefix it with a text element:
+    	@verbatim
+    		<foo>Hullaballoo!<b>This is text</b></foo>
+    	@endverbatim
+		
+		For this XML:
+    	@verbatim
+    		<foo />
+    	@endverbatim
+    	SetText() will generate
+    	@verbatim
+    		<foo>Hullaballoo!</foo>
+    	@endverbatim
+    */
+	void SetText( const char* inText );
+    /// Convenience method for setting text inside and element. See SetText() for important limitations.
+    void SetText( int value );
+    /// Convenience method for setting text inside and element. See SetText() for important limitations.
+    void SetText( unsigned value );  
+    /// Convenience method for setting text inside and element. See SetText() for important limitations.
+    void SetText( bool value );  
+    /// Convenience method for setting text inside and element. See SetText() for important limitations.
+    void SetText( double value );  
+    /// Convenience method for setting text inside and element. See SetText() for important limitations.
+    void SetText( float value );  
+
+    /**
+    	Convenience method to query the value of a child text node. This is probably best
+    	shown by example. Given you have a document is this form:
+    	@verbatim
+    		<point>
+    			<x>1</x>
+    			<y>1.4</y>
+    		</point>
+    	@endverbatim
+
+    	The QueryIntText() and similar functions provide a safe and easier way to get to the
+    	"value" of x and y.
+
+    	@verbatim
+    		int x = 0;
+    		float y = 0;	// types of x and y are contrived for example
+    		const XMLElement* xElement = pointElement->FirstChildElement( "x" );
+    		const XMLElement* yElement = pointElement->FirstChildElement( "y" );
+    		xElement->QueryIntText( &x );
+    		yElement->QueryFloatText( &y );
+    	@endverbatim
+
+    	@returns XML_SUCCESS (0) on success, XML_CAN_NOT_CONVERT_TEXT if the text cannot be converted
+    			 to the requested type, and XML_NO_TEXT_NODE if there is no child text to query.
+
+    */
+    XMLError QueryIntText( int* ival ) const;
+    /// See QueryIntText()
+    XMLError QueryUnsignedText( unsigned* uval ) const;
+    /// See QueryIntText()
+    XMLError QueryBoolText( bool* bval ) const;
+    /// See QueryIntText()
+    XMLError QueryDoubleText( double* dval ) const;
+    /// See QueryIntText()
+    XMLError QueryFloatText( float* fval ) const;
+
+    // internal:
+    enum {
+        OPEN,		// <foo>
+        CLOSED,		// <foo/>
+        CLOSING		// </foo>
+    };
+    int ClosingType() const {
+        return _closingType;
+    }
+    char* ParseDeep( char* p, StrPair* endTag );
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+private:
+    XMLElement( XMLDocument* doc );
+    virtual ~XMLElement();
+    XMLElement( const XMLElement& );	// not supported
+    void operator=( const XMLElement& );	// not supported
+
+    XMLAttribute* FindAttribute( const char* name ) {
+        return const_cast<XMLAttribute*>(const_cast<const XMLElement*>(this)->FindAttribute( name ));
+    }
+    XMLAttribute* FindOrCreateAttribute( const char* name );
+    //void LinkAttribute( XMLAttribute* attrib );
+    char* ParseAttributes( char* p );
+    static void DeleteAttribute( XMLAttribute* attribute );
+
+    enum { BUF_SIZE = 200 };
+    int _closingType;
+    // The attribute list is ordered; there is no 'lastAttribute'
+    // because the list needs to be scanned for dupes before adding
+    // a new attribute.
+    XMLAttribute* _rootAttribute;
+};
+
+
+enum Whitespace {
+    PRESERVE_WHITESPACE,
+    COLLAPSE_WHITESPACE
+};
+
+
+/** A Document binds together all the functionality.
+	It can be saved, loaded, and printed to the screen.
+	All Nodes are connected and allocated to a Document.
+	If the Document is deleted, all its Nodes are also deleted.
+*/
+class TINYXML2_LIB XMLDocument : public XMLNode
+{
+    friend class XMLElement;
+public:
+    /// constructor
+    XMLDocument( bool processEntities = true, Whitespace = PRESERVE_WHITESPACE );
+    ~XMLDocument();
+
+    virtual XMLDocument* ToDocument()				{
+        return this;
+    }
+    virtual const XMLDocument* ToDocument() const	{
+        return this;
+    }
+
+    /**
+    	Parse an XML file from a character string.
+    	Returns XML_NO_ERROR (0) on success, or
+    	an errorID.
+
+    	You may optionally pass in the 'nBytes', which is
+    	the number of bytes which will be parsed. If not
+    	specified, TinyXML-2 will assume 'xml' points to a
+    	null terminated string.
+    */
+    XMLError Parse( const char* xml, size_t nBytes=(size_t)(-1) );
+
+    /**
+    	Load an XML file from disk.
+    	Returns XML_NO_ERROR (0) on success, or
+    	an errorID.
+    */
+    XMLError LoadFile( const char* filename );
+
+    /**
+    	Load an XML file from disk. You are responsible
+    	for providing and closing the FILE*. 
+     
+        NOTE: The file should be opened as binary ("rb")
+        not text in order for TinyXML-2 to correctly
+        do newline normalization.
+
+    	Returns XML_NO_ERROR (0) on success, or
+    	an errorID.
+    */
+    XMLError LoadFile( FILE* );
+
+    /**
+    	Save the XML file to disk.
+    	Returns XML_NO_ERROR (0) on success, or
+    	an errorID.
+    */
+    XMLError SaveFile( const char* filename, bool compact = false );
+
+    /**
+    	Save the XML file to disk. You are responsible
+    	for providing and closing the FILE*.
+
+    	Returns XML_NO_ERROR (0) on success, or
+    	an errorID.
+    */
+    XMLError SaveFile( FILE* fp, bool compact = false );
+
+    bool ProcessEntities() const		{
+        return _processEntities;
+    }
+    Whitespace WhitespaceMode() const	{
+        return _whitespace;
+    }
+
+    /**
+    	Returns true if this document has a leading Byte Order Mark of UTF8.
+    */
+    bool HasBOM() const {
+        return _writeBOM;
+    }
+    /** Sets whether to write the BOM when writing the file.
+    */
+    void SetBOM( bool useBOM ) {
+        _writeBOM = useBOM;
+    }
+
+    /** Return the root element of DOM. Equivalent to FirstChildElement().
+        To get the first node, use FirstChild().
+    */
+    XMLElement* RootElement()				{
+        return FirstChildElement();
+    }
+    const XMLElement* RootElement() const	{
+        return FirstChildElement();
+    }
+
+    /** Print the Document. If the Printer is not provided, it will
+        print to stdout. If you provide Printer, this can print to a file:
+    	@verbatim
+    	XMLPrinter printer( fp );
+    	doc.Print( &printer );
+    	@endverbatim
+
+    	Or you can use a printer to print to memory:
+    	@verbatim
+    	XMLPrinter printer;
+    	doc.Print( &printer );
+    	// printer.CStr() has a const char* to the XML
+    	@endverbatim
+    */
+    void Print( XMLPrinter* streamer=0 ) const;
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    /**
+    	Create a new Element associated with
+    	this Document. The memory for the Element
+    	is managed by the Document.
+    */
+    XMLElement* NewElement( const char* name );
+    /**
+    	Create a new Comment associated with
+    	this Document. The memory for the Comment
+    	is managed by the Document.
+    */
+    XMLComment* NewComment( const char* comment );
+    /**
+    	Create a new Text associated with
+    	this Document. The memory for the Text
+    	is managed by the Document.
+    */
+    XMLText* NewText( const char* text );
+    /**
+    	Create a new Declaration associated with
+    	this Document. The memory for the object
+    	is managed by the Document.
+
+    	If the 'text' param is null, the standard
+    	declaration is used.:
+    	@verbatim
+    		<?xml version="1.0" encoding="UTF-8"?>
+    	@endverbatim
+    */
+    XMLDeclaration* NewDeclaration( const char* text=0 );
+    /**
+    	Create a new Unknown associated with
+    	this Document. The memory for the object
+    	is managed by the Document.
+    */
+    XMLUnknown* NewUnknown( const char* text );
+
+    /**
+    	Delete a node associated with this document.
+    	It will be unlinked from the DOM.
+    */
+    void DeleteNode( XMLNode* node );
+
+    void SetError( XMLError error, const char* str1, const char* str2 );
+
+    /// Return true if there was an error parsing the document.
+    bool Error() const {
+        return _errorID != XML_NO_ERROR;
+    }
+    /// Return the errorID.
+    XMLError  ErrorID() const {
+        return _errorID;
+    }
+	const char* ErrorName() const;
+
+    /// Return a possibly helpful diagnostic location or string.
+    const char* GetErrorStr1() const {
+        return _errorStr1;
+    }
+    /// Return a possibly helpful secondary diagnostic location or string.
+    const char* GetErrorStr2() const {
+        return _errorStr2;
+    }
+    /// If there is an error, print it to stdout.
+    void PrintError() const;
+    
+    /// Clear the document, resetting it to the initial state.
+    void Clear();
+
+    // internal
+    char* Identify( char* p, XMLNode** node );
+
+    virtual XMLNode* ShallowClone( XMLDocument* /*document*/ ) const	{
+        return 0;
+    }
+    virtual bool ShallowEqual( const XMLNode* /*compare*/ ) const	{
+        return false;
+    }
+
+private:
+    XMLDocument( const XMLDocument& );	// not supported
+    void operator=( const XMLDocument& );	// not supported
+
+    bool        _writeBOM;
+    bool        _processEntities;
+    XMLError    _errorID;
+    Whitespace  _whitespace;
+    const char* _errorStr1;
+    const char* _errorStr2;
+    char*       _charBuffer;
+
+    MemPoolT< sizeof(XMLElement) >	 _elementPool;
+    MemPoolT< sizeof(XMLAttribute) > _attributePool;
+    MemPoolT< sizeof(XMLText) >		 _textPool;
+    MemPoolT< sizeof(XMLComment) >	 _commentPool;
+
+	static const char* _errorNames[XML_ERROR_COUNT];
+
+    void Parse();
+};
+
+
+/**
+	A XMLHandle is a class that wraps a node pointer with null checks; this is
+	an incredibly useful thing. Note that XMLHandle is not part of the TinyXML-2
+	DOM structure. It is a separate utility class.
+
+	Take an example:
+	@verbatim
+	<Document>
+		<Element attributeA = "valueA">
+			<Child attributeB = "value1" />
+			<Child attributeB = "value2" />
+		</Element>
+	</Document>
+	@endverbatim
+
+	Assuming you want the value of "attributeB" in the 2nd "Child" element, it's very
+	easy to write a *lot* of code that looks like:
+
+	@verbatim
+	XMLElement* root = document.FirstChildElement( "Document" );
+	if ( root )
+	{
+		XMLElement* element = root->FirstChildElement( "Element" );
+		if ( element )
+		{
+			XMLElement* child = element->FirstChildElement( "Child" );
+			if ( child )
+			{
+				XMLElement* child2 = child->NextSiblingElement( "Child" );
+				if ( child2 )
+				{
+					// Finally do something useful.
+	@endverbatim
+
+	And that doesn't even cover "else" cases. XMLHandle addresses the verbosity
+	of such code. A XMLHandle checks for null pointers so it is perfectly safe
+	and correct to use:
+
+	@verbatim
+	XMLHandle docHandle( &document );
+	XMLElement* child2 = docHandle.FirstChildElement( "Document" ).FirstChildElement( "Element" ).FirstChildElement().NextSiblingElement();
+	if ( child2 )
+	{
+		// do something useful
+	@endverbatim
+
+	Which is MUCH more concise and useful.
+
+	It is also safe to copy handles - internally they are nothing more than node pointers.
+	@verbatim
+	XMLHandle handleCopy = handle;
+	@endverbatim
+
+	See also XMLConstHandle, which is the same as XMLHandle, but operates on const objects.
+*/
+class TINYXML2_LIB XMLHandle
+{
+public:
+    /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
+    XMLHandle( XMLNode* node )												{
+        _node = node;
+    }
+    /// Create a handle from a node.
+    XMLHandle( XMLNode& node )												{
+        _node = &node;
+    }
+    /// Copy constructor
+    XMLHandle( const XMLHandle& ref )										{
+        _node = ref._node;
+    }
+    /// Assignment
+    XMLHandle& operator=( const XMLHandle& ref )							{
+        _node = ref._node;
+        return *this;
+    }
+
+    /// Get the first child of this handle.
+    XMLHandle FirstChild() 													{
+        return XMLHandle( _node ? _node->FirstChild() : 0 );
+    }
+    /// Get the first child element of this handle.
+    XMLHandle FirstChildElement( const char* value=0 )						{
+        return XMLHandle( _node ? _node->FirstChildElement( value ) : 0 );
+    }
+    /// Get the last child of this handle.
+    XMLHandle LastChild()													{
+        return XMLHandle( _node ? _node->LastChild() : 0 );
+    }
+    /// Get the last child element of this handle.
+    XMLHandle LastChildElement( const char* _value=0 )						{
+        return XMLHandle( _node ? _node->LastChildElement( _value ) : 0 );
+    }
+    /// Get the previous sibling of this handle.
+    XMLHandle PreviousSibling()												{
+        return XMLHandle( _node ? _node->PreviousSibling() : 0 );
+    }
+    /// Get the previous sibling element of this handle.
+    XMLHandle PreviousSiblingElement( const char* _value=0 )				{
+        return XMLHandle( _node ? _node->PreviousSiblingElement( _value ) : 0 );
+    }
+    /// Get the next sibling of this handle.
+    XMLHandle NextSibling()													{
+        return XMLHandle( _node ? _node->NextSibling() : 0 );
+    }
+    /// Get the next sibling element of this handle.
+    XMLHandle NextSiblingElement( const char* _value=0 )					{
+        return XMLHandle( _node ? _node->NextSiblingElement( _value ) : 0 );
+    }
+
+    /// Safe cast to XMLNode. This can return null.
+    XMLNode* ToNode()							{
+        return _node;
+    }
+    /// Safe cast to XMLElement. This can return null.
+    XMLElement* ToElement() 					{
+        return ( ( _node == 0 ) ? 0 : _node->ToElement() );
+    }
+    /// Safe cast to XMLText. This can return null.
+    XMLText* ToText() 							{
+        return ( ( _node == 0 ) ? 0 : _node->ToText() );
+    }
+    /// Safe cast to XMLUnknown. This can return null.
+    XMLUnknown* ToUnknown() 					{
+        return ( ( _node == 0 ) ? 0 : _node->ToUnknown() );
+    }
+    /// Safe cast to XMLDeclaration. This can return null.
+    XMLDeclaration* ToDeclaration() 			{
+        return ( ( _node == 0 ) ? 0 : _node->ToDeclaration() );
+    }
+
+private:
+    XMLNode* _node;
+};
+
+
+/**
+	A variant of the XMLHandle class for working with const XMLNodes and Documents. It is the
+	same in all regards, except for the 'const' qualifiers. See XMLHandle for API.
+*/
+class TINYXML2_LIB XMLConstHandle
+{
+public:
+    XMLConstHandle( const XMLNode* node )											{
+        _node = node;
+    }
+    XMLConstHandle( const XMLNode& node )											{
+        _node = &node;
+    }
+    XMLConstHandle( const XMLConstHandle& ref )										{
+        _node = ref._node;
+    }
+
+    XMLConstHandle& operator=( const XMLConstHandle& ref )							{
+        _node = ref._node;
+        return *this;
+    }
+
+    const XMLConstHandle FirstChild() const											{
+        return XMLConstHandle( _node ? _node->FirstChild() : 0 );
+    }
+    const XMLConstHandle FirstChildElement( const char* value=0 ) const				{
+        return XMLConstHandle( _node ? _node->FirstChildElement( value ) : 0 );
+    }
+    const XMLConstHandle LastChild()	const										{
+        return XMLConstHandle( _node ? _node->LastChild() : 0 );
+    }
+    const XMLConstHandle LastChildElement( const char* _value=0 ) const				{
+        return XMLConstHandle( _node ? _node->LastChildElement( _value ) : 0 );
+    }
+    const XMLConstHandle PreviousSibling() const									{
+        return XMLConstHandle( _node ? _node->PreviousSibling() : 0 );
+    }
+    const XMLConstHandle PreviousSiblingElement( const char* _value=0 ) const		{
+        return XMLConstHandle( _node ? _node->PreviousSiblingElement( _value ) : 0 );
+    }
+    const XMLConstHandle NextSibling() const										{
+        return XMLConstHandle( _node ? _node->NextSibling() : 0 );
+    }
+    const XMLConstHandle NextSiblingElement( const char* _value=0 ) const			{
+        return XMLConstHandle( _node ? _node->NextSiblingElement( _value ) : 0 );
+    }
+
+
+    const XMLNode* ToNode() const				{
+        return _node;
+    }
+    const XMLElement* ToElement() const			{
+        return ( ( _node == 0 ) ? 0 : _node->ToElement() );
+    }
+    const XMLText* ToText() const				{
+        return ( ( _node == 0 ) ? 0 : _node->ToText() );
+    }
+    const XMLUnknown* ToUnknown() const			{
+        return ( ( _node == 0 ) ? 0 : _node->ToUnknown() );
+    }
+    const XMLDeclaration* ToDeclaration() const	{
+        return ( ( _node == 0 ) ? 0 : _node->ToDeclaration() );
+    }
+
+private:
+    const XMLNode* _node;
+};
+
+
+/**
+	Printing functionality. The XMLPrinter gives you more
+	options than the XMLDocument::Print() method.
+
+	It can:
+	-# Print to memory.
+	-# Print to a file you provide.
+	-# Print XML without a XMLDocument.
+
+	Print to Memory
+
+	@verbatim
+	XMLPrinter printer;
+	doc.Print( &printer );
+	SomeFunction( printer.CStr() );
+	@endverbatim
+
+	Print to a File
+
+	You provide the file pointer.
+	@verbatim
+	XMLPrinter printer( fp );
+	doc.Print( &printer );
+	@endverbatim
+
+	Print without a XMLDocument
+
+	When loading, an XML parser is very useful. However, sometimes
+	when saving, it just gets in the way. The code is often set up
+	for streaming, and constructing the DOM is just overhead.
+
+	The Printer supports the streaming case. The following code
+	prints out a trivially simple XML file without ever creating
+	an XML document.
+
+	@verbatim
+	XMLPrinter printer( fp );
+	printer.OpenElement( "foo" );
+	printer.PushAttribute( "foo", "bar" );
+	printer.CloseElement();
+	@endverbatim
+*/
+class TINYXML2_LIB XMLPrinter : public XMLVisitor
+{
+public:
+    /** Construct the printer. If the FILE* is specified,
+    	this will print to the FILE. Else it will print
+    	to memory, and the result is available in CStr().
+    	If 'compact' is set to true, then output is created
+    	with only required whitespace and newlines.
+    */
+    XMLPrinter( FILE* file=0, bool compact = false, int depth = 0 );
+    virtual ~XMLPrinter()	{}
+
+    /** If streaming, write the BOM and declaration. */
+    void PushHeader( bool writeBOM, bool writeDeclaration );
+    /** If streaming, start writing an element.
+        The element must be closed with CloseElement()
+    */
+    void OpenElement( const char* name, bool compactMode=false );
+    /// If streaming, add an attribute to an open element.
+    void PushAttribute( const char* name, const char* value );
+    void PushAttribute( const char* name, int value );
+    void PushAttribute( const char* name, unsigned value );
+    void PushAttribute( const char* name, bool value );
+    void PushAttribute( const char* name, double value );
+    /// If streaming, close the Element.
+    virtual void CloseElement( bool compactMode=false );
+
+    /// Add a text node.
+    void PushText( const char* text, bool cdata=false );
+    /// Add a text node from an integer.
+    void PushText( int value );
+    /// Add a text node from an unsigned.
+    void PushText( unsigned value );
+    /// Add a text node from a bool.
+    void PushText( bool value );
+    /// Add a text node from a float.
+    void PushText( float value );
+    /// Add a text node from a double.
+    void PushText( double value );
+
+    /// Add a comment
+    void PushComment( const char* comment );
+
+    void PushDeclaration( const char* value );
+    void PushUnknown( const char* value );
+
+    virtual bool VisitEnter( const XMLDocument& /*doc*/ );
+    virtual bool VisitExit( const XMLDocument& /*doc*/ )			{
+        return true;
+    }
+
+    virtual bool VisitEnter( const XMLElement& element, const XMLAttribute* attribute );
+    virtual bool VisitExit( const XMLElement& element );
+
+    virtual bool Visit( const XMLText& text );
+    virtual bool Visit( const XMLComment& comment );
+    virtual bool Visit( const XMLDeclaration& declaration );
+    virtual bool Visit( const XMLUnknown& unknown );
+
+    /**
+    	If in print to memory mode, return a pointer to
+    	the XML file in memory.
+    */
+    const char* CStr() const {
+        return _buffer.Mem();
+    }
+    /**
+    	If in print to memory mode, return the size
+    	of the XML file in memory. (Note the size returned
+    	includes the terminating null.)
+    */
+    int CStrSize() const {
+        return _buffer.Size();
+    }
+    /**
+    	If in print to memory mode, reset the buffer to the
+    	beginning.
+    */
+    void ClearBuffer() {
+        _buffer.Clear();
+        _buffer.Push(0);
+    }
+
+protected:
+	virtual bool CompactMode( const XMLElement& )	{ return _compactMode; }
+
+	/** Prints out the space before an element. You may override to change
+	    the space and tabs used. A PrintSpace() override should call Print().
+	*/
+    virtual void PrintSpace( int depth );
+    void Print( const char* format, ... );
+
+    void SealElementIfJustOpened();
+    bool _elementJustOpened;
+    DynArray< const char*, 10 > _stack;
+
+private:
+    void PrintString( const char*, bool restrictedEntitySet );	// prints out, after detecting entities.
+
+    bool _firstElement;
+    FILE* _fp;
+    int _depth;
+    int _textDepth;
+    bool _processEntities;
+	bool _compactMode;
+
+    enum {
+        ENTITY_RANGE = 64,
+        BUF_SIZE = 200
+    };
+    bool _entityFlag[ENTITY_RANGE];
+    bool _restrictedEntityFlag[ENTITY_RANGE];
+
+    DynArray< char, 20 > _buffer;
+};
+
+
+}	// tinyxml2
+
+#if defined(_MSC_VER)
+#   pragma warning(pop)
+#endif
+
+#endif // TINYXML2_INCLUDED

--- a/tinyxml2-3.0.0/tinyxml2.pc.in
+++ b/tinyxml2-3.0.0/tinyxml2.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: TinyXML2
+Description: simple, small, C++ XML parser
+Version: @GENERIC_LIB_VERSION@
+Libs: -L${libdir} -ltinyxml2
+Cflags: -I${includedir}

--- a/tinyxml2-3.0.0/tinyxml2/test.vcxproj
+++ b/tinyxml2-3.0.0/tinyxml2/test.vcxproj
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug-Dll|Win32">
+      <Configuration>Debug-Dll</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Dll|x64">
+      <Configuration>Debug-Dll</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Lib|Win32">
+      <Configuration>Debug-Lib</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Lib|x64">
+      <Configuration>Debug-Lib</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Dll|Win32">
+      <Configuration>Release-Dll</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Dll|x64">
+      <Configuration>Release-Dll</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Lib|Win32">
+      <Configuration>Release-Lib</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Lib|x64">
+      <Configuration>Release-Lib</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}</ProjectGuid>
+    <RootNamespace>test</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release-Lib|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|Win32'">
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|Win32'">
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|Win32'">
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|Win32'">
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|Win32'">
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|Win32'">
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|Win32'">
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|Win32'">
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|x64'">
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|x64'">
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|x64'">
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|x64'">
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|x64'">
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|x64'">
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|x64'">
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|x64'">
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>TINYXML2_IMPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>TINYXML2_IMPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <PreprocessorDefinitions>TINYXML2_IMPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <PreprocessorDefinitions>TINYXML2_IMPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\xmltest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="tinyxml2.vcxproj">
+      <Project>{d1c528b6-aa02-4d29-9d61-dc08e317a70d}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tinyxml2-3.0.0/tinyxml2/test.vcxproj.filters
+++ b/tinyxml2-3.0.0/tinyxml2/test.vcxproj.filters
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\xmltest.cpp" />
+  </ItemGroup>
+</Project>

--- a/tinyxml2-3.0.0/tinyxml2/tinyxml2-cbp/README
+++ b/tinyxml2-3.0.0/tinyxml2/tinyxml2-cbp/README
@@ -1,0 +1,3 @@
+The (default) Release configuration of this project builds a ready to use static library.
+The Debug configuration of this project builds an executable console application that 
+executes all tests provided for tinyxml2 in the xmltest.cpp file.

--- a/tinyxml2-3.0.0/tinyxml2/tinyxml2-cbp/tinyxml2-cbp.cbp
+++ b/tinyxml2-3.0.0/tinyxml2/tinyxml2-cbp/tinyxml2-cbp.cbp
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocks_project_file>
+	<FileVersion major="1" minor="6" />
+	<Project>
+		<Option title="tinyxml2-cbp" />
+		<Option execution_dir="../" />
+		<Option pch_mode="2" />
+		<Option compiler="gcc" />
+		<Build>
+			<Target title="Release">
+				<Option output="bin/Release/tinyxml2" prefix_auto="1" extension_auto="1" />
+				<Option working_dir="" />
+				<Option object_output="obj/Release/" />
+				<Option type="2" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-O2" />
+				</Compiler>
+				<Linker>
+					<Add option="-s" />
+				</Linker>
+			</Target>
+			<Target title="Debug">
+				<Option output="bin/Debug/tinyxml2-cbp" prefix_auto="1" extension_auto="1" />
+				<Option working_dir="../../" />
+				<Option object_output="obj/Debug/" />
+				<Option type="1" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-g" />
+				</Compiler>
+			</Target>
+		</Build>
+		<Compiler>
+			<Add option="-Wall" />
+		</Compiler>
+		<Unit filename="../../tinyxml2.cpp" />
+		<Unit filename="../../tinyxml2.h" />
+		<Unit filename="../../xmltest.cpp">
+			<Option target="Debug" />
+		</Unit>
+		<Extensions>
+			<code_completion />
+			<envvars />
+			<debugger />
+			<lib_finder disable_auto="1" />
+		</Extensions>
+	</Project>
+</CodeBlocks_project_file>

--- a/tinyxml2-3.0.0/tinyxml2/tinyxml2.sln
+++ b/tinyxml2-3.0.0/tinyxml2/tinyxml2.sln
@@ -1,0 +1,56 @@
+
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tinyxml2", "tinyxml2.vcxproj", "{D1C528B6-AA02-4D29-9D61-DC08E317A70D}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test", "test.vcxproj", "{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug-Dll|Win32 = Debug-Dll|Win32
+		Debug-Dll|x64 = Debug-Dll|x64
+		Debug-Lib|Win32 = Debug-Lib|Win32
+		Debug-Lib|x64 = Debug-Lib|x64
+		Release-Dll|Win32 = Release-Dll|Win32
+		Release-Dll|x64 = Release-Dll|x64
+		Release-Lib|Win32 = Release-Lib|Win32
+		Release-Lib|x64 = Release-Lib|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Debug-Dll|Win32.ActiveCfg = Debug-Dll|Win32
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Debug-Dll|Win32.Build.0 = Debug-Dll|Win32
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Debug-Dll|x64.ActiveCfg = Debug-Dll|x64
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Debug-Dll|x64.Build.0 = Debug-Dll|x64
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Debug-Lib|Win32.ActiveCfg = Debug-Lib|Win32
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Debug-Lib|Win32.Build.0 = Debug-Lib|Win32
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Debug-Lib|x64.ActiveCfg = Debug-Lib|x64
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Debug-Lib|x64.Build.0 = Debug-Lib|x64
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Release-Dll|Win32.ActiveCfg = Release-Dll|Win32
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Release-Dll|Win32.Build.0 = Release-Dll|Win32
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Release-Dll|x64.ActiveCfg = Release-Dll|x64
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Release-Dll|x64.Build.0 = Release-Dll|x64
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Release-Lib|Win32.ActiveCfg = Release-Lib|Win32
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Release-Lib|Win32.Build.0 = Release-Lib|Win32
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Release-Lib|x64.ActiveCfg = Release-Lib|x64
+		{D1C528B6-AA02-4D29-9D61-DC08E317A70D}.Release-Lib|x64.Build.0 = Release-Lib|x64
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Debug-Dll|Win32.ActiveCfg = Debug-Dll|Win32
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Debug-Dll|Win32.Build.0 = Debug-Dll|Win32
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Debug-Dll|x64.ActiveCfg = Debug-Dll|x64
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Debug-Dll|x64.Build.0 = Debug-Dll|x64
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Debug-Lib|Win32.ActiveCfg = Debug-Lib|Win32
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Debug-Lib|Win32.Build.0 = Debug-Lib|Win32
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Debug-Lib|x64.ActiveCfg = Debug-Lib|x64
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Debug-Lib|x64.Build.0 = Debug-Lib|x64
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Release-Dll|Win32.ActiveCfg = Release-Dll|Win32
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Release-Dll|Win32.Build.0 = Release-Dll|Win32
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Release-Dll|x64.ActiveCfg = Release-Dll|x64
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Release-Dll|x64.Build.0 = Release-Dll|x64
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Release-Lib|Win32.ActiveCfg = Release-Lib|Win32
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Release-Lib|Win32.Build.0 = Release-Lib|Win32
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Release-Lib|x64.ActiveCfg = Release-Lib|x64
+		{E8FB2712-8666-4662-A5B8-2B5B0FB1A260}.Release-Lib|x64.Build.0 = Release-Lib|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tinyxml2-3.0.0/tinyxml2/tinyxml2.vcxproj
+++ b/tinyxml2-3.0.0/tinyxml2/tinyxml2.vcxproj
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug-Dll|Win32">
+      <Configuration>Debug-Dll</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Dll|x64">
+      <Configuration>Debug-Dll</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Lib|Win32">
+      <Configuration>Debug-Lib</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-Lib|x64">
+      <Configuration>Debug-Lib</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Dll|Win32">
+      <Configuration>Release-Dll</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Dll|x64">
+      <Configuration>Release-Dll</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Lib|Win32">
+      <Configuration>Release-Lib</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-Lib|x64">
+      <Configuration>Release-Lib</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D1C528B6-AA02-4D29-9D61-DC08E317A70D}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>tinyxml2</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release-Lib|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Platform)-$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)temp\$(Platform)-$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;TINYXML2_EXPORT;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>NotSet</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Lib|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Dll|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;TINYXML2_EXPORT;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>NotSet</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;TINYXML2_EXPORT;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>NotSet</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Lib|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Dll|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;TINYXML2_EXPORT;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>NotSet</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SetChecksum>true</SetChecksum>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Lib>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Lib>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+    <ClCompile>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+    </ClCompile>
+    <ClCompile>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <ClCompile>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <ClCompile>
+      <OmitFramePointers>true</OmitFramePointers>
+    </ClCompile>
+    <ClCompile>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Lib>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Lib>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+    <ClCompile>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+    </ClCompile>
+    <ClCompile>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <ClCompile>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <ClCompile>
+      <OmitFramePointers>true</OmitFramePointers>
+    </ClCompile>
+    <ClCompile>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\tinyxml2.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\tinyxml2.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tinyxml2-3.0.0/tinyxml2/tinyxml2.vcxproj.filters
+++ b/tinyxml2-3.0.0/tinyxml2/tinyxml2.vcxproj.filters
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\tinyxml2.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\tinyxml2.h" />
+  </ItemGroup>
+</Project>

--- a/tinyxml2-3.0.0/tinyxml2/tinyxml2.xcodeproj/project.pbxproj
+++ b/tinyxml2-3.0.0/tinyxml2/tinyxml2.xcodeproj/project.pbxproj
@@ -1,0 +1,211 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		037AE8A5151E692700E0F29F /* xmltest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 037AE8A3151E692700E0F29F /* xmltest.cpp */; };
+		03F28B53152E9B1B00D4CD90 /* tinyxml2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03F28B4A152E9B1B00D4CD90 /* tinyxml2.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		037AE86D151E685F00E0F29F /* xmltest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = xmltest; sourceTree = BUILT_PRODUCTS_DIR; };
+		037AE8A3151E692700E0F29F /* xmltest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = xmltest.cpp; path = ../xmltest.cpp; sourceTree = SOURCE_ROOT; };
+		03F28B4A152E9B1B00D4CD90 /* tinyxml2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tinyxml2.cpp; sourceTree = "<group>"; };
+		03F28B4B152E9B1B00D4CD90 /* tinyxml2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tinyxml2.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		037AE86B151E685F00E0F29F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		037AE056151CCC5200E0F29F = {
+			isa = PBXGroup;
+			children = (
+				037AE069151CCC7000E0F29F /* Classes */,
+				03F28B60152E9B4C00D4CD90 /* Libraries */,
+				037AE06F151CCCB900E0F29F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		037AE069151CCC7000E0F29F /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				037AE8A3151E692700E0F29F /* xmltest.cpp */,
+			);
+			name = Classes;
+			sourceTree = "<group>";
+		};
+		037AE06F151CCCB900E0F29F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				037AE86D151E685F00E0F29F /* xmltest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		03F28AD7152E9B1B00D4CD90 /* tinyxml2 */ = {
+			isa = PBXGroup;
+			children = (
+				03F28B4A152E9B1B00D4CD90 /* tinyxml2.cpp */,
+				03F28B4B152E9B1B00D4CD90 /* tinyxml2.h */,
+			);
+			name = tinyxml2;
+			path = ..;
+			sourceTree = SOURCE_ROOT;
+		};
+		03F28B60152E9B4C00D4CD90 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				03F28AD7152E9B1B00D4CD90 /* tinyxml2 */,
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		037AE86C151E685F00E0F29F /* xmltest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 037AE873151E687E00E0F29F /* Build configuration list for PBXNativeTarget "xmltest" */;
+			buildPhases = (
+				037AE86A151E685F00E0F29F /* Sources */,
+				037AE86B151E685F00E0F29F /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = xmltest;
+			productName = tinyxml2;
+			productReference = 037AE86D151E685F00E0F29F /* xmltest */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		037AE058151CCC5200E0F29F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+			};
+			buildConfigurationList = 037AE05B151CCC5200E0F29F /* Build configuration list for PBXProject "tinyxml2" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 037AE056151CCC5200E0F29F;
+			productRefGroup = 037AE06F151CCCB900E0F29F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				037AE86C151E685F00E0F29F /* xmltest */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		037AE86A151E685F00E0F29F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				037AE8A5151E692700E0F29F /* xmltest.cpp in Sources */,
+				03F28B53152E9B1B00D4CD90 /* tinyxml2.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		037AE059151CCC5200E0F29F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)/Debug";
+				COPY_PHASE_STRIP = NO;
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = DEBUG;
+				ONLY_ACTIVE_ARCH = YES;
+				SYMROOT = build;
+			};
+			name = Debug;
+		};
+		037AE05A151CCC5200E0F29F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = YES;
+			};
+			name = Release;
+		};
+		037AE86F151E686000E0F29F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = ..;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_FIX_AND_CONTINUE = YES;
+				GCC_MODEL_TUNING = G5;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = "";
+				PREBINDING = NO;
+				PRODUCT_NAME = xmltest;
+			};
+			name = Debug;
+		};
+		037AE870151E686000E0F29F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = ..;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_ENABLE_FIX_AND_CONTINUE = NO;
+				GCC_MODEL_TUNING = G5;
+				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = "";
+				PREBINDING = NO;
+				PRODUCT_NAME = tinyxml2;
+				ZERO_LINK = NO;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		037AE05B151CCC5200E0F29F /* Build configuration list for PBXProject "tinyxml2" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				037AE059151CCC5200E0F29F /* Debug */,
+				037AE05A151CCC5200E0F29F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		037AE873151E687E00E0F29F /* Build configuration list for PBXNativeTarget "xmltest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				037AE86F151E686000E0F29F /* Debug */,
+				037AE870151E686000E0F29F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 037AE058151CCC5200E0F29F /* Project object */;
+}

--- a/tinyxml2-3.0.0/xmltest.cpp
+++ b/tinyxml2-3.0.0/xmltest.cpp
@@ -1,0 +1,1489 @@
+#if defined( _MSC_VER )
+	#if !defined( _CRT_SECURE_NO_WARNINGS )
+		#define _CRT_SECURE_NO_WARNINGS		// This test file is not intended to be secure.
+	#endif
+#endif
+
+#include "tinyxml2.h"
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+#if defined( _MSC_VER )
+	#include <direct.h>		// _mkdir
+	#include <crtdbg.h>
+	#define WIN32_LEAN_AND_MEAN
+	#include <windows.h>
+	_CrtMemState startMemState;
+	_CrtMemState endMemState;
+#elif defined(MINGW32) || defined(__MINGW32__)
+    #include <io.h>  // mkdir
+#else
+	#include <sys/stat.h>	// mkdir
+#endif
+
+using namespace tinyxml2;
+using namespace std;
+int gPass = 0;
+int gFail = 0;
+
+
+bool XMLTest (const char* testString, const char* expected, const char* found, bool echo=true, bool extraNL=false )
+{
+	bool pass = !strcmp( expected, found );
+	if ( pass )
+		printf ("[pass]");
+	else
+		printf ("[fail]");
+
+	if ( !echo ) {
+		printf (" %s\n", testString);
+	}
+	else {
+		if ( extraNL ) {
+			printf( " %s\n", testString );
+			printf( "%s\n", expected );
+			printf( "%s\n", found );
+		}
+		else {
+			printf (" %s [%s][%s]\n", testString, expected, found);
+		}
+	}
+
+	if ( pass )
+		++gPass;
+	else
+		++gFail;
+	return pass;
+}
+
+
+template< class T > bool XMLTest( const char* testString, T expected, T found, bool echo=true )
+{
+	bool pass = ( expected == found );
+	if ( pass )
+		printf ("[pass]");
+	else
+		printf ("[fail]");
+
+	if ( !echo )
+		printf (" %s\n", testString);
+	else
+		printf (" %s [%d][%d]\n", testString, static_cast<int>(expected), static_cast<int>(found) );
+
+	if ( pass )
+		++gPass;
+	else
+		++gFail;
+	return pass;
+}
+
+
+void NullLineEndings( char* p )
+{
+	while( p && *p ) {
+		if ( *p == '\n' || *p == '\r' ) {
+			*p = 0;
+			return;
+		}
+		++p;
+	}
+}
+
+
+int example_1()
+{
+	XMLDocument doc;
+	doc.LoadFile( "resources/dream.xml" );
+
+	return doc.ErrorID();
+}
+/** @page Example-1 Load an XML File
+ *  @dontinclude ./xmltest.cpp
+ *  Basic XML file loading.
+ *  The basic syntax to load an XML file from
+ *  disk and check for an error. (ErrorID()
+ *  will return 0 for no error.)
+ *  @skip example_1()
+ *  @until }
+ */
+ 
+
+int example_2()
+{
+	static const char* xml = "<element/>";
+	XMLDocument doc;
+	doc.Parse( xml );
+
+	return doc.ErrorID();
+}
+/** @page Example-2 Parse an XML from char buffer
+ *  @dontinclude ./xmltest.cpp
+ *  Basic XML string parsing.
+ *  The basic syntax to parse an XML for
+ *  a char* and check for an error. (ErrorID()
+ *  will return 0 for no error.)
+ *  @skip example_2()
+ *  @until }
+ */
+
+
+int example_3()
+{
+	static const char* xml =
+		"<?xml version=\"1.0\"?>"
+		"<!DOCTYPE PLAY SYSTEM \"play.dtd\">"
+		"<PLAY>"
+		"<TITLE>A Midsummer Night's Dream</TITLE>"
+		"</PLAY>";
+
+	XMLDocument doc;
+	doc.Parse( xml );
+
+	XMLElement* titleElement = doc.FirstChildElement( "PLAY" )->FirstChildElement( "TITLE" );
+	const char* title = titleElement->GetText();
+	printf( "Name of play (1): %s\n", title );
+
+	XMLText* textNode = titleElement->FirstChild()->ToText();
+	title = textNode->Value();
+	printf( "Name of play (2): %s\n", title );
+
+	return doc.ErrorID();
+}
+/** @page Example-3 Get information out of XML
+	@dontinclude ./xmltest.cpp
+	In this example, we navigate a simple XML
+	file, and read some interesting text. Note
+	that this example doesn't use error
+	checking; working code should check for null
+	pointers when walking an XML tree, or use
+	XMLHandle.
+	
+	(The XML is an excerpt from "dream.xml"). 
+
+	@skip example_3()
+	@until </PLAY>";
+
+	The structure of the XML file is:
+
+	<ul>
+		<li>(declaration)</li>
+		<li>(dtd stuff)</li>
+		<li>Element "PLAY"</li>
+		<ul>
+			<li>Element "TITLE"</li>
+			<ul>
+			    <li>Text "A Midsummer Night's Dream"</li>
+			</ul>
+		</ul>
+	</ul>
+
+	For this example, we want to print out the 
+	title of the play. The text of the title (what
+	we want) is child of the "TITLE" element which
+	is a child of the "PLAY" element.
+
+	We want to skip the declaration and dtd, so the
+	method FirstChildElement() is a good choice. The
+	FirstChildElement() of the Document is the "PLAY"
+	Element, the FirstChildElement() of the "PLAY" Element
+	is the "TITLE" Element.
+
+	@until ( "TITLE" );
+
+	We can then use the convenience function GetText()
+	to get the title of the play.
+
+	@until title );
+
+	Text is just another Node in the XML DOM. And in
+	fact you should be a little cautious with it, as
+	text nodes can contain elements. 
+	
+	@verbatim
+	Consider: A Midsummer Night's <b>Dream</b>
+	@endverbatim
+
+	It is more correct to actually query the Text Node
+	if in doubt:
+
+	@until title );
+
+	Noting that here we use FirstChild() since we are
+	looking for XMLText, not an element, and ToText()
+	is a cast from a Node to a XMLText. 
+*/
+
+
+bool example_4()
+{
+	static const char* xml =
+		"<information>"
+		"	<attributeApproach v='2' />"
+		"	<textApproach>"
+		"		<v>2</v>"
+		"	</textApproach>"
+		"</information>";
+
+	XMLDocument doc;
+	doc.Parse( xml );
+
+	int v0 = 0;
+	int v1 = 0;
+
+	XMLElement* attributeApproachElement = doc.FirstChildElement()->FirstChildElement( "attributeApproach" );
+	attributeApproachElement->QueryIntAttribute( "v", &v0 );
+
+	XMLElement* textApproachElement = doc.FirstChildElement()->FirstChildElement( "textApproach" );
+	textApproachElement->FirstChildElement( "v" )->QueryIntText( &v1 );
+
+	printf( "Both values are the same: %d and %d\n", v0, v1 );
+
+	return !doc.Error() && ( v0 == v1 );
+}
+/** @page Example-4 Read attributes and text information.
+	@dontinclude ./xmltest.cpp
+
+	There are fundamentally 2 ways of writing a key-value
+	pair into an XML file. (Something that's always annoyed
+	me about XML.) Either by using attributes, or by writing
+	the key name into an element and the value into
+	the text node wrapped by the element. Both approaches
+	are illustrated in this example, which shows two ways
+	to encode the value "2" into the key "v":
+
+	@skip example_4()
+	@until "</information>";
+
+	TinyXML-2 has accessors for both approaches. 
+
+	When using an attribute, you navigate to the XMLElement
+	with that attribute and use the QueryIntAttribute()
+	group of methods. (Also QueryFloatAttribute(), etc.)
+
+	@skip XMLElement* attributeApproachElement
+	@until &v0 );
+
+	When using the text approach, you need to navigate
+	down one more step to the XMLElement that contains
+	the text. Note the extra FirstChildElement( "v" )
+	in the code below. The value of the text can then
+	be safely queried with the QueryIntText() group
+	of methods. (Also QueryFloatText(), etc.)
+
+	@skip XMLElement* textApproachElement
+	@until &v1 );
+*/
+
+
+int main( int argc, const char ** argv )
+{
+	#if defined( _MSC_VER ) && defined( DEBUG )
+		_CrtMemCheckpoint( &startMemState );
+		// Enable MS Visual C++ debug heap memory leaks dump on exit
+		_CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) | _CRTDBG_LEAK_CHECK_DF);
+	#endif
+
+	#if defined(_MSC_VER) || defined(MINGW32) || defined(__MINGW32__)
+		#if defined __MINGW64_VERSION_MAJOR && defined __MINGW64_VERSION_MINOR
+			//MINGW64: both 32 and 64-bit
+			mkdir( "resources/out/" );
+                #else
+                	_mkdir( "resources/out/" );
+                #endif
+	#else
+		mkdir( "resources/out/", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+	#endif
+
+	{
+		TIXMLASSERT( true );
+	}
+
+	if ( argc > 1 ) {
+		XMLDocument* doc = new XMLDocument();
+		clock_t startTime = clock();
+		doc->LoadFile( argv[1] );
+ 		clock_t loadTime = clock();
+		int errorID = doc->ErrorID();
+		delete doc; doc = 0;
+ 		clock_t deleteTime = clock();
+
+		printf( "Test file '%s' loaded. ErrorID=%d\n", argv[1], errorID );
+		if ( !errorID ) {
+			printf( "Load time=%u\n",   (unsigned)(loadTime - startTime) );
+			printf( "Delete time=%u\n", (unsigned)(deleteTime - loadTime) );
+			printf( "Total time=%u\n",  (unsigned)(deleteTime - startTime) );
+		}
+		exit(0);
+	}
+
+	FILE* fp = fopen( "resources/dream.xml", "r" );
+	if ( !fp ) {
+		printf( "Error opening test file 'dream.xml'.\n"
+				"Is your working directory the same as where \n"
+				"the xmltest.cpp and dream.xml file are?\n\n"
+	#if defined( _MSC_VER )
+				"In windows Visual Studio you may need to set\n"
+				"Properties->Debugging->Working Directory to '..'\n"
+	#endif
+			  );
+		exit( 1 );
+	}
+	fclose( fp );
+
+	XMLTest( "Example-1", 0, example_1() );
+	XMLTest( "Example-2", 0, example_2() );
+	XMLTest( "Example-3", 0, example_3() );
+	XMLTest( "Example-4", true, example_4() );
+
+	/* ------ Example 2: Lookup information. ---- */
+
+	{
+		static const char* test[] = {	"<element />",
+										"<element></element>",
+										"<element><subelement/></element>",
+										"<element><subelement></subelement></element>",
+										"<element><subelement><subsub/></subelement></element>",
+										"<!--comment beside elements--><element><subelement></subelement></element>",
+										"<!--comment beside elements, this time with spaces-->  \n <element>  <subelement> \n </subelement> </element>",
+										"<element attrib1='foo' attrib2=\"bar\" ></element>",
+										"<element attrib1='foo' attrib2=\"bar\" ><subelement attrib3='yeehaa' /></element>",
+										"<element>Text inside element.</element>",
+										"<element><b></b></element>",
+										"<element>Text inside and <b>bolded</b> in the element.</element>",
+										"<outer><element>Text inside and <b>bolded</b> in the element.</element></outer>",
+										"<element>This &amp; That.</element>",
+										"<element attrib='This&lt;That' />",
+										0
+		};
+		for( int i=0; test[i]; ++i ) {
+			XMLDocument doc;
+			doc.Parse( test[i] );
+			doc.Print();
+			printf( "----------------------------------------------\n" );
+		}
+	}
+#if 1
+	{
+		static const char* test = "<!--hello world\n"
+								  "          line 2\r"
+								  "          line 3\r\n"
+								  "          line 4\n\r"
+								  "          line 5\r-->";
+
+		XMLDocument doc;
+		doc.Parse( test );
+		doc.Print();
+	}
+
+	{
+		static const char* test = "<element>Text before.</element>";
+		XMLDocument doc;
+		doc.Parse( test );
+		XMLElement* root = doc.FirstChildElement();
+		XMLElement* newElement = doc.NewElement( "Subelement" );
+		root->InsertEndChild( newElement );
+		doc.Print();
+	}
+	{
+		XMLDocument* doc = new XMLDocument();
+		static const char* test = "<element><sub/></element>";
+		doc->Parse( test );
+		delete doc;
+	}
+	{
+		// Test: Programmatic DOM
+		// Build:
+		//		<element>
+		//			<!--comment-->
+		//			<sub attrib="1" />
+		//			<sub attrib="2" />
+		//			<sub attrib="3" >& Text!</sub>
+		//		<element>
+
+		XMLDocument* doc = new XMLDocument();
+		XMLNode* element = doc->InsertEndChild( doc->NewElement( "element" ) );
+
+		XMLElement* sub[3] = { doc->NewElement( "sub" ), doc->NewElement( "sub" ), doc->NewElement( "sub" ) };
+		for( int i=0; i<3; ++i ) {
+			sub[i]->SetAttribute( "attrib", i );
+		}
+		element->InsertEndChild( sub[2] );
+		XMLNode* comment = element->InsertFirstChild( doc->NewComment( "comment" ) );
+		element->InsertAfterChild( comment, sub[0] );
+		element->InsertAfterChild( sub[0], sub[1] );
+		sub[2]->InsertFirstChild( doc->NewText( "& Text!" ));
+		doc->Print();
+		XMLTest( "Programmatic DOM", "comment", doc->FirstChildElement( "element" )->FirstChild()->Value() );
+		XMLTest( "Programmatic DOM", "0", doc->FirstChildElement( "element" )->FirstChildElement()->Attribute( "attrib" ) );
+		XMLTest( "Programmatic DOM", 2, doc->FirstChildElement()->LastChildElement( "sub" )->IntAttribute( "attrib" ) );
+		XMLTest( "Programmatic DOM", "& Text!",
+				 doc->FirstChildElement()->LastChildElement( "sub" )->FirstChild()->ToText()->Value() );
+
+		// And now deletion:
+		element->DeleteChild( sub[2] );
+		doc->DeleteNode( comment );
+
+		element->FirstChildElement()->SetAttribute( "attrib", true );
+		element->LastChildElement()->DeleteAttribute( "attrib" );
+
+		XMLTest( "Programmatic DOM", true, doc->FirstChildElement()->FirstChildElement()->BoolAttribute( "attrib" ) );
+		int value = 10;
+		int result = doc->FirstChildElement()->LastChildElement()->QueryIntAttribute( "attrib", &value );
+		XMLTest( "Programmatic DOM", result, (int)XML_NO_ATTRIBUTE );
+		XMLTest( "Programmatic DOM", value, 10 );
+
+		doc->Print();
+
+		{
+			XMLPrinter streamer;
+			doc->Print( &streamer );
+			printf( "%s", streamer.CStr() );
+		}
+		{
+			XMLPrinter streamer( 0, true );
+			doc->Print( &streamer );
+			XMLTest( "Compact mode", "<element><sub attrib=\"1\"/><sub/></element>", streamer.CStr(), false );
+		}
+		doc->SaveFile( "./resources/out/pretty.xml" );
+		doc->SaveFile( "./resources/out/compact.xml", true );
+		delete doc;
+	}
+	{
+		// Test: Dream
+		// XML1 : 1,187,569 bytes	in 31,209 allocations
+		// XML2 :   469,073	bytes	in    323 allocations
+		//int newStart = gNew;
+		XMLDocument doc;
+		doc.LoadFile( "resources/dream.xml" );
+
+		doc.SaveFile( "resources/out/dreamout.xml" );
+		doc.PrintError();
+
+		XMLTest( "Dream", "xml version=\"1.0\"",
+						  doc.FirstChild()->ToDeclaration()->Value() );
+		XMLTest( "Dream", true, doc.FirstChild()->NextSibling()->ToUnknown() ? true : false );
+		XMLTest( "Dream", "DOCTYPE PLAY SYSTEM \"play.dtd\"",
+						  doc.FirstChild()->NextSibling()->ToUnknown()->Value() );
+		XMLTest( "Dream", "And Robin shall restore amends.",
+						  doc.LastChild()->LastChild()->LastChild()->LastChild()->LastChildElement()->GetText() );
+		XMLTest( "Dream", "And Robin shall restore amends.",
+						  doc.LastChild()->LastChild()->LastChild()->LastChild()->LastChildElement()->GetText() );
+
+		XMLDocument doc2;
+		doc2.LoadFile( "resources/out/dreamout.xml" );
+		XMLTest( "Dream-out", "xml version=\"1.0\"",
+						  doc2.FirstChild()->ToDeclaration()->Value() );
+		XMLTest( "Dream-out", true, doc2.FirstChild()->NextSibling()->ToUnknown() ? true : false );
+		XMLTest( "Dream-out", "DOCTYPE PLAY SYSTEM \"play.dtd\"",
+						  doc2.FirstChild()->NextSibling()->ToUnknown()->Value() );
+		XMLTest( "Dream-out", "And Robin shall restore amends.",
+						  doc2.LastChild()->LastChild()->LastChild()->LastChild()->LastChildElement()->GetText() );
+
+		//gNewTotal = gNew - newStart;
+	}
+
+
+	{
+		const char* error =	"<?xml version=\"1.0\" standalone=\"no\" ?>\n"
+							"<passages count=\"006\" formatversion=\"20020620\">\n"
+							"    <wrong error>\n"
+							"</passages>";
+
+		XMLDocument doc;
+		doc.Parse( error );
+		XMLTest( "Bad XML", doc.ErrorID(), XML_ERROR_PARSING_ATTRIBUTE );
+	}
+
+	{
+		const char* str = "<doc attr0='1' attr1='2.0' attr2='foo' />";
+
+		XMLDocument doc;
+		doc.Parse( str );
+
+		XMLElement* ele = doc.FirstChildElement();
+
+		int iVal, result;
+		double dVal;
+
+		result = ele->QueryDoubleAttribute( "attr0", &dVal );
+		XMLTest( "Query attribute: int as double", result, (int)XML_NO_ERROR );
+		XMLTest( "Query attribute: int as double", (int)dVal, 1 );
+		result = ele->QueryDoubleAttribute( "attr1", &dVal );
+		XMLTest( "Query attribute: double as double", result, (int)XML_NO_ERROR );
+		XMLTest( "Query attribute: double as double", (int)dVal, 2 );
+		result = ele->QueryIntAttribute( "attr1", &iVal );
+		XMLTest( "Query attribute: double as int", result, (int)XML_NO_ERROR );
+		XMLTest( "Query attribute: double as int", iVal, 2 );
+		result = ele->QueryIntAttribute( "attr2", &iVal );
+		XMLTest( "Query attribute: not a number", result, (int)XML_WRONG_ATTRIBUTE_TYPE );
+		result = ele->QueryIntAttribute( "bar", &iVal );
+		XMLTest( "Query attribute: does not exist", result, (int)XML_NO_ATTRIBUTE );
+	}
+
+	{
+		const char* str = "<doc/>";
+
+		XMLDocument doc;
+		doc.Parse( str );
+
+		XMLElement* ele = doc.FirstChildElement();
+
+		int iVal, iVal2;
+		double dVal, dVal2;
+
+		ele->SetAttribute( "str", "strValue" );
+		ele->SetAttribute( "int", 1 );
+		ele->SetAttribute( "double", -1.0 );
+
+		const char* cStr = ele->Attribute( "str" );
+		ele->QueryIntAttribute( "int", &iVal );
+		ele->QueryDoubleAttribute( "double", &dVal );
+
+		ele->QueryAttribute( "int", &iVal2 );
+		ele->QueryAttribute( "double", &dVal2 );
+
+		XMLTest( "Attribute match test", ele->Attribute( "str", "strValue" ), "strValue" );
+		XMLTest( "Attribute round trip. c-string.", "strValue", cStr );
+		XMLTest( "Attribute round trip. int.", 1, iVal );
+		XMLTest( "Attribute round trip. double.", -1, (int)dVal );
+		XMLTest( "Alternate query", true, iVal == iVal2 );
+		XMLTest( "Alternate query", true, dVal == dVal2 );
+	}
+
+	{
+		XMLDocument doc;
+		doc.LoadFile( "resources/utf8test.xml" );
+
+		// Get the attribute "value" from the "Russian" element and check it.
+		XMLElement* element = doc.FirstChildElement( "document" )->FirstChildElement( "Russian" );
+		const unsigned char correctValue[] = {	0xd1U, 0x86U, 0xd0U, 0xb5U, 0xd0U, 0xbdU, 0xd0U, 0xbdU,
+												0xd0U, 0xbeU, 0xd1U, 0x81U, 0xd1U, 0x82U, 0xd1U, 0x8cU, 0 };
+
+		XMLTest( "UTF-8: Russian value.", (const char*)correctValue, element->Attribute( "value" ) );
+
+		const unsigned char russianElementName[] = {	0xd0U, 0xa0U, 0xd1U, 0x83U,
+														0xd1U, 0x81U, 0xd1U, 0x81U,
+														0xd0U, 0xbaU, 0xd0U, 0xb8U,
+														0xd0U, 0xb9U, 0 };
+		const char russianText[] = "<\xD0\xB8\xD0\xBC\xD0\xB5\xD0\xB5\xD1\x82>";
+
+		XMLText* text = doc.FirstChildElement( "document" )->FirstChildElement( (const char*) russianElementName )->FirstChild()->ToText();
+		XMLTest( "UTF-8: Browsing russian element name.",
+				 russianText,
+				 text->Value() );
+
+		// Now try for a round trip.
+		doc.SaveFile( "resources/out/utf8testout.xml" );
+
+		// Check the round trip.
+		int okay = 0;
+
+		FILE* saved  = fopen( "resources/out/utf8testout.xml", "r" );
+		FILE* verify = fopen( "resources/utf8testverify.xml", "r" );
+
+		if ( saved && verify )
+		{
+			okay = 1;
+			char verifyBuf[256];
+			while ( fgets( verifyBuf, 256, verify ) )
+			{
+				char savedBuf[256];
+				fgets( savedBuf, 256, saved );
+				NullLineEndings( verifyBuf );
+				NullLineEndings( savedBuf );
+
+				if ( strcmp( verifyBuf, savedBuf ) )
+				{
+					printf( "verify:%s<\n", verifyBuf );
+					printf( "saved :%s<\n", savedBuf );
+					okay = 0;
+					break;
+				}
+			}
+		}
+		if ( saved )
+			fclose( saved );
+		if ( verify )
+			fclose( verify );
+		XMLTest( "UTF-8: Verified multi-language round trip.", 1, okay );
+	}
+
+	// --------GetText()-----------
+	{
+		const char* str = "<foo>This is  text</foo>";
+		XMLDocument doc;
+		doc.Parse( str );
+		const XMLElement* element = doc.RootElement();
+
+		XMLTest( "GetText() normal use.", "This is  text", element->GetText() );
+
+		str = "<foo><b>This is text</b></foo>";
+		doc.Parse( str );
+		element = doc.RootElement();
+
+		XMLTest( "GetText() contained element.", element->GetText() == 0, true );
+	}
+
+
+	// --------SetText()-----------
+	{
+		const char* str = "<foo></foo>";
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLElement* element = doc.RootElement();
+
+		element->SetText("darkness.");
+		XMLTest( "SetText() normal use (open/close).", "darkness.", element->GetText() );
+
+		element->SetText("blue flame.");
+		XMLTest( "SetText() replace.", "blue flame.", element->GetText() );
+
+		str = "<foo/>";
+		doc.Parse( str );
+		element = doc.RootElement();
+
+		element->SetText("The driver");
+		XMLTest( "SetText() normal use. (self-closing)", "The driver", element->GetText() );
+
+		element->SetText("<b>horses</b>");
+		XMLTest( "SetText() replace with tag-like text.", "<b>horses</b>", element->GetText() );
+		//doc.Print();
+
+		str = "<foo><bar>Text in nested element</bar></foo>";
+		doc.Parse( str );
+		element = doc.RootElement();
+		
+		element->SetText("wolves");
+		XMLTest( "SetText() prefix to nested non-text children.", "wolves", element->GetText() );
+
+		str = "<foo/>";
+		doc.Parse( str );
+		element = doc.RootElement();
+		
+		element->SetText( "str" );
+		XMLTest( "SetText types", "str", element->GetText() );
+
+		element->SetText( 1 );
+		XMLTest( "SetText types", "1", element->GetText() );
+
+		element->SetText( 1U );
+		XMLTest( "SetText types", "1", element->GetText() );
+
+		element->SetText( true );
+		XMLTest( "SetText types", "1", element->GetText() ); // TODO: should be 'true'?
+
+		element->SetText( 1.5f );
+		XMLTest( "SetText types", "1.5", element->GetText() );
+
+		element->SetText( 1.5 );
+		XMLTest( "SetText types", "1.5", element->GetText() );
+	}
+
+
+	// ---------- CDATA ---------------
+	{
+		const char* str =	"<xmlElement>"
+								"<![CDATA["
+									"I am > the rules!\n"
+									"...since I make symbolic puns"
+								"]]>"
+							"</xmlElement>";
+		XMLDocument doc;
+		doc.Parse( str );
+		doc.Print();
+
+		XMLTest( "CDATA parse.", doc.FirstChildElement()->FirstChild()->Value(),
+								 "I am > the rules!\n...since I make symbolic puns",
+								 false );
+	}
+
+	// ----------- CDATA -------------
+	{
+		const char* str =	"<xmlElement>"
+								"<![CDATA["
+									"<b>I am > the rules!</b>\n"
+									"...since I make symbolic puns"
+								"]]>"
+							"</xmlElement>";
+		XMLDocument doc;
+		doc.Parse( str );
+		doc.Print();
+
+		XMLTest( "CDATA parse. [ tixml1:1480107 ]", doc.FirstChildElement()->FirstChild()->Value(),
+								 "<b>I am > the rules!</b>\n...since I make symbolic puns",
+								 false );
+	}
+
+	// InsertAfterChild causes crash.
+	{
+		// InsertBeforeChild and InsertAfterChild causes crash.
+		XMLDocument doc;
+		XMLElement* parent = doc.NewElement( "Parent" );
+		doc.InsertFirstChild( parent );
+
+		XMLElement* childText0 = doc.NewElement( "childText0" );
+		XMLElement* childText1 = doc.NewElement( "childText1" );
+
+		XMLNode* childNode0 = parent->InsertEndChild( childText0 );
+		XMLNode* childNode1 = parent->InsertAfterChild( childNode0, childText1 );
+
+		XMLTest( "Test InsertAfterChild on empty node. ", ( childNode1 == parent->LastChild() ), true );
+	}
+
+	{
+		// Entities not being written correctly.
+		// From Lynn Allen
+
+		const char* passages =
+			"<?xml version=\"1.0\" standalone=\"no\" ?>"
+			"<passages count=\"006\" formatversion=\"20020620\">"
+				"<psg context=\"Line 5 has &quot;quotation marks&quot; and &apos;apostrophe marks&apos;."
+				" It also has &lt;, &gt;, and &amp;, as well as a fake copyright &#xA9;.\"> </psg>"
+			"</passages>";
+
+		XMLDocument doc;
+		doc.Parse( passages );
+		XMLElement* psg = doc.RootElement()->FirstChildElement();
+		const char* context = psg->Attribute( "context" );
+		const char* expected = "Line 5 has \"quotation marks\" and 'apostrophe marks'. It also has <, >, and &, as well as a fake copyright \xC2\xA9.";
+
+		XMLTest( "Entity transformation: read. ", expected, context, true );
+
+		FILE* textfile = fopen( "resources/out/textfile.txt", "w" );
+		if ( textfile )
+		{
+			XMLPrinter streamer( textfile );
+			psg->Accept( &streamer );
+			fclose( textfile );
+		}
+
+        textfile = fopen( "resources/out/textfile.txt", "r" );
+		TIXMLASSERT( textfile );
+		if ( textfile )
+		{
+			char buf[ 1024 ];
+			fgets( buf, 1024, textfile );
+			XMLTest( "Entity transformation: write. ",
+					 "<psg context=\"Line 5 has &quot;quotation marks&quot; and &apos;apostrophe marks&apos;."
+					 " It also has &lt;, &gt;, and &amp;, as well as a fake copyright \xC2\xA9.\"/>\n",
+					 buf, false );
+			fclose( textfile );
+		}
+	}
+
+	{
+		// Suppress entities.
+		const char* passages =
+			"<?xml version=\"1.0\" standalone=\"no\" ?>"
+			"<passages count=\"006\" formatversion=\"20020620\">"
+				"<psg context=\"Line 5 has &quot;quotation marks&quot; and &apos;apostrophe marks&apos;.\">Crazy &ttk;</psg>"
+			"</passages>";
+
+		XMLDocument doc( false );
+		doc.Parse( passages );
+
+		XMLTest( "No entity parsing.", doc.FirstChildElement()->FirstChildElement()->Attribute( "context" ),
+				 "Line 5 has &quot;quotation marks&quot; and &apos;apostrophe marks&apos;." );
+		XMLTest( "No entity parsing.", doc.FirstChildElement()->FirstChildElement()->FirstChild()->Value(),
+				 "Crazy &ttk;" );
+		doc.Print();
+	}
+
+	{
+		const char* test = "<?xml version='1.0'?><a.elem xmi.version='2.0'/>";
+
+		XMLDocument doc;
+		doc.Parse( test );
+		XMLTest( "dot in names", doc.Error(), false );
+		XMLTest( "dot in names", doc.FirstChildElement()->Name(), "a.elem" );
+		XMLTest( "dot in names", doc.FirstChildElement()->Attribute( "xmi.version" ), "2.0" );
+	}
+
+	{
+		const char* test = "<element><Name>1.1 Start easy ignore fin thickness&#xA;</Name></element>";
+
+		XMLDocument doc;
+		doc.Parse( test );
+
+		XMLText* text = doc.FirstChildElement()->FirstChildElement()->FirstChild()->ToText();
+		XMLTest( "Entity with one digit.",
+				 text->Value(), "1.1 Start easy ignore fin thickness\n",
+				 false );
+	}
+
+	{
+		// DOCTYPE not preserved (950171)
+		//
+		const char* doctype =
+			"<?xml version=\"1.0\" ?>"
+			"<!DOCTYPE PLAY SYSTEM 'play.dtd'>"
+			"<!ELEMENT title (#PCDATA)>"
+			"<!ELEMENT books (title,authors)>"
+			"<element />";
+
+		XMLDocument doc;
+		doc.Parse( doctype );
+		doc.SaveFile( "resources/out/test7.xml" );
+		doc.DeleteChild( doc.RootElement() );
+		doc.LoadFile( "resources/out/test7.xml" );
+		doc.Print();
+
+		const XMLUnknown* decl = doc.FirstChild()->NextSibling()->ToUnknown();
+		XMLTest( "Correct value of unknown.", "DOCTYPE PLAY SYSTEM 'play.dtd'", decl->Value() );
+
+	}
+
+	{
+		// Comments do not stream out correctly.
+		const char* doctype =
+			"<!-- Somewhat<evil> -->";
+		XMLDocument doc;
+		doc.Parse( doctype );
+
+		XMLComment* comment = doc.FirstChild()->ToComment();
+
+		XMLTest( "Comment formatting.", " Somewhat<evil> ", comment->Value() );
+	}
+	{
+		// Double attributes
+		const char* doctype = "<element attr='red' attr='blue' />";
+
+		XMLDocument doc;
+		doc.Parse( doctype );
+
+		XMLTest( "Parsing repeated attributes.", XML_ERROR_PARSING_ATTRIBUTE, doc.ErrorID() );	// is an  error to tinyxml (didn't use to be, but caused issues)
+		doc.PrintError();
+	}
+
+	{
+		// Embedded null in stream.
+		const char* doctype = "<element att\0r='red' attr='blue' />";
+
+		XMLDocument doc;
+		doc.Parse( doctype );
+		XMLTest( "Embedded null throws error.", true, doc.Error() );
+	}
+
+	{
+		// Empty documents should return TIXML_XML_ERROR_PARSING_EMPTY, bug 1070717
+		const char* str = "";
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "Empty document error", XML_ERROR_EMPTY_DOCUMENT, doc.ErrorID() );
+	}
+
+	{
+		// Documents with all whitespaces should return TIXML_XML_ERROR_PARSING_EMPTY, bug 1070717
+		const char* str = "    ";
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "All whitespaces document error", XML_ERROR_EMPTY_DOCUMENT, doc.ErrorID() );
+	}
+
+	{
+		// Low entities
+		XMLDocument doc;
+		doc.Parse( "<test>&#x0e;</test>" );
+		const char result[] = { 0x0e, 0 };
+		XMLTest( "Low entities.", doc.FirstChildElement()->GetText(), result );
+		doc.Print();
+	}
+
+	{
+		// Attribute values with trailing quotes not handled correctly
+		XMLDocument doc;
+		doc.Parse( "<foo attribute=bar\" />" );
+		XMLTest( "Throw error with bad end quotes.", doc.Error(), true );
+	}
+
+	{
+		// [ 1663758 ] Failure to report error on bad XML
+		XMLDocument xml;
+		xml.Parse("<x>");
+		XMLTest("Missing end tag at end of input", xml.Error(), true);
+		xml.Parse("<x> ");
+		XMLTest("Missing end tag with trailing whitespace", xml.Error(), true);
+		xml.Parse("<x></y>");
+		XMLTest("Mismatched tags", xml.ErrorID(), XML_ERROR_MISMATCHED_ELEMENT);
+	}
+
+
+	{
+		// [ 1475201 ] TinyXML parses entities in comments
+		XMLDocument xml;
+		xml.Parse("<!-- declarations for <head> & <body> -->"
+				  "<!-- far &amp; away -->" );
+
+		XMLNode* e0 = xml.FirstChild();
+		XMLNode* e1 = e0->NextSibling();
+		XMLComment* c0 = e0->ToComment();
+		XMLComment* c1 = e1->ToComment();
+
+		XMLTest( "Comments ignore entities.", " declarations for <head> & <body> ", c0->Value(), true );
+		XMLTest( "Comments ignore entities.", " far &amp; away ", c1->Value(), true );
+	}
+
+	{
+		XMLDocument xml;
+		xml.Parse( "<Parent>"
+						"<child1 att=''/>"
+						"<!-- With this comment, child2 will not be parsed! -->"
+						"<child2 att=''/>"
+					"</Parent>" );
+		xml.Print();
+
+		int count = 0;
+
+		for( XMLNode* ele = xml.FirstChildElement( "Parent" )->FirstChild();
+			 ele;
+			 ele = ele->NextSibling() )
+		{
+			++count;
+		}
+
+		XMLTest( "Comments iterate correctly.", 3, count );
+	}
+
+	{
+		// trying to repro ]1874301]. If it doesn't go into an infinite loop, all is well.
+		unsigned char buf[] = "<?xml version=\"1.0\" encoding=\"utf-8\"?><feed><![CDATA[Test XMLblablablalblbl";
+		buf[60] = 239;
+		buf[61] = 0;
+
+		XMLDocument doc;
+		doc.Parse( (const char*)buf);
+	}
+
+
+	{
+		// bug 1827248 Error while parsing a little bit malformed file
+		// Actually not malformed - should work.
+		XMLDocument xml;
+		xml.Parse( "<attributelist> </attributelist >" );
+		XMLTest( "Handle end tag whitespace", false, xml.Error() );
+	}
+
+	{
+		// This one must not result in an infinite loop
+		XMLDocument xml;
+		xml.Parse( "<infinite>loop" );
+		XMLTest( "Infinite loop test.", true, true );
+	}
+#endif
+	{
+		const char* pub = "<?xml version='1.0'?> <element><sub/></element> <!--comment--> <!DOCTYPE>";
+		XMLDocument doc;
+		doc.Parse( pub );
+
+		XMLDocument clone;
+		for( const XMLNode* node=doc.FirstChild(); node; node=node->NextSibling() ) {
+			XMLNode* copy = node->ShallowClone( &clone );
+			clone.InsertEndChild( copy );
+		}
+
+		clone.Print();
+
+		int count=0;
+		const XMLNode* a=clone.FirstChild();
+		const XMLNode* b=doc.FirstChild();
+		for( ; a && b; a=a->NextSibling(), b=b->NextSibling() ) {
+			++count;
+			XMLTest( "Clone and Equal", true, a->ShallowEqual( b ));
+		}
+		XMLTest( "Clone and Equal", 4, count );
+	}
+
+	{
+		// This shouldn't crash.
+		XMLDocument doc;
+		if(XML_NO_ERROR != doc.LoadFile( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ))
+		{
+			doc.PrintError();
+		}
+		XMLTest( "Error in snprinf handling.", true, doc.Error() );
+	}
+
+	{
+		// Attribute ordering.
+		static const char* xml = "<element attrib1=\"1\" attrib2=\"2\" attrib3=\"3\" />";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLElement* ele = doc.FirstChildElement();
+
+		const XMLAttribute* a = ele->FirstAttribute();
+		XMLTest( "Attribute order", "1", a->Value() );
+		a = a->Next();
+		XMLTest( "Attribute order", "2", a->Value() );
+		a = a->Next();
+		XMLTest( "Attribute order", "3", a->Value() );
+		XMLTest( "Attribute order", "attrib3", a->Name() );
+
+		ele->DeleteAttribute( "attrib2" );
+		a = ele->FirstAttribute();
+		XMLTest( "Attribute order", "1", a->Value() );
+		a = a->Next();
+		XMLTest( "Attribute order", "3", a->Value() );
+
+		ele->DeleteAttribute( "attrib1" );
+		ele->DeleteAttribute( "attrib3" );
+		XMLTest( "Attribute order (empty)", false, ele->FirstAttribute() ? true : false );
+	}
+
+	{
+		// Make sure an attribute with a space in it succeeds.
+		static const char* xml0 = "<element attribute1= \"Test Attribute\"/>";
+		static const char* xml1 = "<element attribute1 =\"Test Attribute\"/>";
+		static const char* xml2 = "<element attribute1 = \"Test Attribute\"/>";
+		XMLDocument doc0;
+		doc0.Parse( xml0 );
+		XMLDocument doc1;
+		doc1.Parse( xml1 );
+		XMLDocument doc2;
+		doc2.Parse( xml2 );
+
+		XMLElement* ele = 0;
+		ele = doc0.FirstChildElement();
+		XMLTest( "Attribute with space #1", "Test Attribute", ele->Attribute( "attribute1" ) );
+		ele = doc1.FirstChildElement();
+		XMLTest( "Attribute with space #2", "Test Attribute", ele->Attribute( "attribute1" ) );
+		ele = doc2.FirstChildElement();
+		XMLTest( "Attribute with space #3", "Test Attribute", ele->Attribute( "attribute1" ) );
+	}
+
+	{
+		// Make sure we don't go into an infinite loop.
+		static const char* xml = "<doc><element attribute='attribute'/><element attribute='attribute'/></doc>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLElement* ele0 = doc.FirstChildElement()->FirstChildElement();
+		XMLElement* ele1 = ele0->NextSiblingElement();
+		bool equal = ele0->ShallowEqual( ele1 );
+
+		XMLTest( "Infinite loop in shallow equal.", true, equal );
+	}
+
+	// -------- Handles ------------
+	{
+		static const char* xml = "<element attrib='bar'><sub>Text</sub></element>";
+		XMLDocument doc;
+		doc.Parse( xml );
+
+		XMLElement* ele = XMLHandle( doc ).FirstChildElement( "element" ).FirstChild().ToElement();
+		XMLTest( "Handle, success, mutable", ele->Value(), "sub" );
+
+		XMLHandle docH( doc );
+		ele = docH.FirstChildElement( "none" ).FirstChildElement( "element" ).ToElement();
+		XMLTest( "Handle, dne, mutable", false, ele != 0 );
+	}
+
+	{
+		static const char* xml = "<element attrib='bar'><sub>Text</sub></element>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLConstHandle docH( doc );
+
+		const XMLElement* ele = docH.FirstChildElement( "element" ).FirstChild().ToElement();
+		XMLTest( "Handle, success, const", ele->Value(), "sub" );
+
+		ele = docH.FirstChildElement( "none" ).FirstChildElement( "element" ).ToElement();
+		XMLTest( "Handle, dne, const", false, ele != 0 );
+	}
+	{
+		// Default Declaration & BOM
+		XMLDocument doc;
+		doc.InsertEndChild( doc.NewDeclaration() );
+		doc.SetBOM( true );
+
+		XMLPrinter printer;
+		doc.Print( &printer );
+
+		static const char* result  = "\xef\xbb\xbf<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+		XMLTest( "BOM and default declaration", printer.CStr(), result, false );
+		XMLTest( "CStrSize", printer.CStrSize(), 42, false );
+	}
+	{
+		const char* xml = "<ipxml ws='1'><info bla=' /></ipxml>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Ill formed XML", true, doc.Error() );
+	}
+
+	// QueryXYZText
+	{
+		const char* xml = "<point> <x>1.2</x> <y>1</y> <z>38</z> <valid>true</valid> </point>";
+		XMLDocument doc;
+		doc.Parse( xml );
+
+		const XMLElement* pointElement = doc.RootElement();
+
+		int intValue = 0;
+		unsigned unsignedValue = 0;
+		float floatValue = 0;
+		double doubleValue = 0;
+		bool boolValue = false;
+
+		pointElement->FirstChildElement( "y" )->QueryIntText( &intValue );
+		pointElement->FirstChildElement( "y" )->QueryUnsignedText( &unsignedValue );
+		pointElement->FirstChildElement( "x" )->QueryFloatText( &floatValue );
+		pointElement->FirstChildElement( "x" )->QueryDoubleText( &doubleValue );
+		pointElement->FirstChildElement( "valid" )->QueryBoolText( &boolValue );
+
+
+		XMLTest( "QueryIntText", intValue, 1,						false );
+		XMLTest( "QueryUnsignedText", unsignedValue, (unsigned)1,	false );
+		XMLTest( "QueryFloatText", floatValue, 1.2f,				false );
+		XMLTest( "QueryDoubleText", doubleValue, 1.2,				false );
+		XMLTest( "QueryBoolText", boolValue, true,					false );
+	}
+
+	{
+		const char* xml = "<element><_sub/><:sub/><sub:sub/><sub-sub/></element>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Non-alpha element lead letter parses.", doc.Error(), false );
+	}
+    
+    {
+        const char* xml = "<element _attr1=\"foo\" :attr2=\"bar\"></element>";
+        XMLDocument doc;
+        doc.Parse( xml );
+        XMLTest("Non-alpha attribute lead character parses.", doc.Error(), false);
+    }
+    
+    {
+        const char* xml = "<3lement></3lement>";
+        XMLDocument doc;
+        doc.Parse( xml );
+        XMLTest("Element names with lead digit fail to parse.", doc.Error(), true);
+    }
+
+	{
+		const char* xml = "<element/>WOA THIS ISN'T GOING TO PARSE";
+		XMLDocument doc;
+		doc.Parse( xml, 10 );
+		XMLTest( "Set length of incoming data", doc.Error(), false );
+	}
+
+    {
+        XMLDocument doc;
+        doc.LoadFile( "resources/dream.xml" );
+        XMLTest( "Document has something to Clear()", doc.NoChildren(), false );
+        doc.Clear();
+        XMLTest( "Document Clear()'s", doc.NoChildren(), true );
+    }
+    
+	// ----------- Whitespace ------------
+	{
+		const char* xml = "<element>"
+							"<a> This \nis &apos;  text  &apos; </a>"
+							"<b>  This is &apos; text &apos;  \n</b>"
+							"<c>This  is  &apos;  \n\n text &apos;</c>"
+						  "</element>";
+		XMLDocument doc( true, COLLAPSE_WHITESPACE );
+		doc.Parse( xml );
+
+		const XMLElement* element = doc.FirstChildElement();
+		for( const XMLElement* parent = element->FirstChildElement();
+			 parent;
+			 parent = parent->NextSiblingElement() )
+		{
+			XMLTest( "Whitespace collapse", "This is ' text '", parent->GetText() );
+		}
+	}
+
+#if 0
+	{
+		// Passes if assert doesn't fire.
+		XMLDocument xmlDoc;
+
+	    xmlDoc.NewDeclaration();
+	    xmlDoc.NewComment("Configuration file");
+
+	    XMLElement *root = xmlDoc.NewElement("settings");
+	    root->SetAttribute("version", 2);
+	}
+#endif
+
+	{
+		const char* xml = "<element>    </element>";
+		XMLDocument doc( true, COLLAPSE_WHITESPACE );
+		doc.Parse( xml );
+		XMLTest( "Whitespace  all space", true, 0 == doc.FirstChildElement()->FirstChild() );
+	}
+
+	{
+		// An assert should not fire.
+		const char* xml = "<element/>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLElement* ele = doc.NewElement( "unused" );		// This will get cleaned up with the 'doc' going out of scope.
+		XMLTest( "Tracking unused elements", true, ele != 0, false );
+	}
+
+
+	{
+		const char* xml = "<parent><child>abc</child></parent>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLElement* ele = doc.FirstChildElement( "parent")->FirstChildElement( "child");
+
+		XMLPrinter printer;
+		ele->Accept( &printer );
+		XMLTest( "Printing of sub-element", "<child>abc</child>\n", printer.CStr(), false );
+	}
+
+
+	{
+		XMLDocument doc;
+		XMLError error = doc.LoadFile( "resources/empty.xml" );
+		XMLTest( "Loading an empty file", XML_ERROR_EMPTY_DOCUMENT, error );
+		XMLTest( "Loading an empty file and ErrorName as string", "XML_ERROR_EMPTY_DOCUMENT", doc.ErrorName() );
+		doc.PrintError();
+	}
+
+	{
+        // BOM preservation
+        static const char* xml_bom_preservation  = "\xef\xbb\xbf<element/>\n";
+        {
+			XMLDocument doc;
+			XMLTest( "BOM preservation (parse)", XML_NO_ERROR, doc.Parse( xml_bom_preservation ), false );
+            XMLPrinter printer;
+            doc.Print( &printer );
+
+            XMLTest( "BOM preservation (compare)", xml_bom_preservation, printer.CStr(), false, true );
+			doc.SaveFile( "resources/bomtest.xml" );
+        }
+		{
+			XMLDocument doc;
+			doc.LoadFile( "resources/bomtest.xml" );
+			XMLTest( "BOM preservation (load)", true, doc.HasBOM(), false );
+
+            XMLPrinter printer;
+            doc.Print( &printer );
+            XMLTest( "BOM preservation (compare)", xml_bom_preservation, printer.CStr(), false, true );
+		}
+	}
+
+	{
+		// Insertion with Removal
+		const char* xml = "<?xml version=\"1.0\" ?>"
+			"<root>"
+			"<one>"
+			"<subtree>"
+			"<elem>element 1</elem>text<!-- comment -->"
+			"</subtree>"
+			"</one>"
+			"<two/>"
+			"</root>";
+		const char* xmlInsideTwo = "<?xml version=\"1.0\" ?>"
+			"<root>"
+			"<one/>"
+			"<two>"
+			"<subtree>"
+			"<elem>element 1</elem>text<!-- comment -->"
+			"</subtree>"
+			"</two>"
+			"</root>";
+		const char* xmlAfterOne = "<?xml version=\"1.0\" ?>"
+			"<root>"
+			"<one/>"
+			"<subtree>"
+			"<elem>element 1</elem>text<!-- comment -->"
+			"</subtree>"
+			"<two/>"
+			"</root>";
+		const char* xmlAfterTwo = "<?xml version=\"1.0\" ?>"
+			"<root>"
+			"<one/>"
+			"<two/>"
+			"<subtree>"
+			"<elem>element 1</elem>text<!-- comment -->"
+			"</subtree>"
+			"</root>";
+
+		XMLDocument doc;
+		doc.Parse(xml);
+		XMLElement* subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
+		XMLElement* two = doc.RootElement()->FirstChildElement("two");
+		two->InsertFirstChild(subtree);
+		XMLPrinter printer1(0, true);
+		doc.Accept(&printer1);
+		XMLTest("Move node from within <one> to <two>", xmlInsideTwo, printer1.CStr());
+
+		doc.Parse(xml);
+		subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
+		two = doc.RootElement()->FirstChildElement("two");
+		doc.RootElement()->InsertAfterChild(two, subtree);
+		XMLPrinter printer2(0, true);
+		doc.Accept(&printer2);
+		XMLTest("Move node from within <one> after <two>", xmlAfterTwo, printer2.CStr(), false);
+
+		doc.Parse(xml);
+		XMLNode* one = doc.RootElement()->FirstChildElement("one");
+		subtree = one->FirstChildElement("subtree");
+		doc.RootElement()->InsertAfterChild(one, subtree);
+		XMLPrinter printer3(0, true);
+		doc.Accept(&printer3);
+		XMLTest("Move node from within <one> after <one>", xmlAfterOne, printer3.CStr(), false);
+
+		doc.Parse(xml);
+		subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
+		two = doc.RootElement()->FirstChildElement("two");
+		doc.RootElement()->InsertEndChild(subtree);
+		XMLPrinter printer4(0, true);
+		doc.Accept(&printer4);
+		XMLTest("Move node from within <one> after <two>", xmlAfterTwo, printer4.CStr(), false);
+	}
+
+	{
+		const char* xml = "<svg width = \"128\" height = \"128\">"
+			"	<text> </text>"
+			"</svg>";
+		XMLDocument doc;
+		doc.Parse(xml);
+		doc.Print();
+	}
+
+	{
+		// Test that it doesn't crash.
+		const char* xml = "<?xml version=\"1.0\"?><root><sample><field0><1</field0><field1>2</field1></sample></root>";
+		XMLDocument doc;
+		doc.Parse(xml);
+		doc.PrintError();
+	}
+
+#if 1
+		// the question being explored is what kind of print to use: 
+		// https://github.com/leethomason/tinyxml2/issues/63
+	{
+		//const char* xml = "<element attrA='123456789.123456789' attrB='1.001e9' attrC='1.0e-10' attrD='1001000000.000000' attrE='0.1234567890123456789'/>";
+		const char* xml = "<element/>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		doc.FirstChildElement()->SetAttribute( "attrA-f64", 123456789.123456789 );
+		doc.FirstChildElement()->SetAttribute( "attrB-f64", 1.001e9 );
+		doc.FirstChildElement()->SetAttribute( "attrC-f64", 1.0e9 );
+		doc.FirstChildElement()->SetAttribute( "attrC-f64", 1.0e20 );
+		doc.FirstChildElement()->SetAttribute( "attrD-f64", 1.0e-10 );
+		doc.FirstChildElement()->SetAttribute( "attrD-f64", 0.123456789 );
+
+		doc.FirstChildElement()->SetAttribute( "attrA-f32", 123456789.123456789f );
+		doc.FirstChildElement()->SetAttribute( "attrB-f32", 1.001e9f );
+		doc.FirstChildElement()->SetAttribute( "attrC-f32", 1.0e9f );
+		doc.FirstChildElement()->SetAttribute( "attrC-f32", 1.0e20f );
+		doc.FirstChildElement()->SetAttribute( "attrD-f32", 1.0e-10f );
+		doc.FirstChildElement()->SetAttribute( "attrD-f32", 0.123456789f );
+
+		doc.Print();
+
+		/* The result of this test is platform, compiler, and library version dependent. :("
+		XMLPrinter printer;
+		doc.Print( &printer );
+		XMLTest( "Float and double formatting.", 
+			"<element attrA-f64=\"123456789.12345679\" attrB-f64=\"1001000000\" attrC-f64=\"1e+20\" attrD-f64=\"0.123456789\" attrA-f32=\"1.2345679e+08\" attrB-f32=\"1.001e+09\" attrC-f32=\"1e+20\" attrD-f32=\"0.12345679\"/>\n",
+			printer.CStr(), 
+			true );
+		*/
+	}
+#endif
+    
+    {
+        // Issue #184
+        // If it doesn't assert, it passes. Caused by objects
+        // getting created during parsing which are then
+        // inaccessible in the memory pools.
+        {
+            XMLDocument doc;
+            doc.Parse("<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>");
+        }
+        {
+            XMLDocument doc;
+            doc.Parse("<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>");
+            doc.Clear();
+        }
+    }
+    
+    {
+        // If this doesn't assert in DEBUG, all is well.
+        tinyxml2::XMLDocument doc;
+        tinyxml2::XMLElement *pRoot = doc.NewElement("Root");
+        doc.DeleteNode(pRoot);
+    }
+
+	{
+		// Should not assert in DEBUG
+		XMLPrinter printer;
+	}
+
+	{
+		// Issue 291. Should not crash
+		const char* xml = "&#0</a>";
+		XMLDocument doc;
+		doc.Parse( xml );
+
+		XMLPrinter printer;
+		doc.Print( &printer );
+	}
+
+	// ----------- Performance tracking --------------
+	{
+#if defined( _MSC_VER )
+		__int64 start, end, freq;
+		QueryPerformanceFrequency( (LARGE_INTEGER*) &freq );
+#endif
+
+		FILE* fp  = fopen( "resources/dream.xml", "r" );
+		fseek( fp, 0, SEEK_END );
+		long size = ftell( fp );
+		fseek( fp, 0, SEEK_SET );
+
+		char* mem = new char[size+1];
+		fread( mem, size, 1, fp );
+		fclose( fp );
+		mem[size] = 0;
+
+#if defined( _MSC_VER )
+		QueryPerformanceCounter( (LARGE_INTEGER*) &start );
+#else
+		clock_t cstart = clock();
+#endif
+		static const int COUNT = 10;
+		for( int i=0; i<COUNT; ++i ) {
+			XMLDocument doc;
+			doc.Parse( mem );
+		}
+#if defined( _MSC_VER )
+		QueryPerformanceCounter( (LARGE_INTEGER*) &end );
+#else
+		clock_t cend = clock();
+#endif
+
+		delete [] mem;
+
+		static const char* note =
+#ifdef DEBUG
+			"DEBUG";
+#else
+			"Release";
+#endif
+
+#if defined( _MSC_VER )
+		printf( "\nParsing %s of dream.xml: %.3f milli-seconds\n", note, 1000.0 * (double)(end-start) / ( (double)freq * (double)COUNT) );
+#else
+		printf( "\nParsing %s of dream.xml: %.3f milli-seconds\n", note, (double)(cend - cstart)/(double)COUNT );
+#endif
+	}
+
+	#if defined( _MSC_VER ) &&  defined( DEBUG )
+		_CrtMemCheckpoint( &endMemState );
+
+		_CrtMemState diffMemState;
+		_CrtMemDifference( &diffMemState, &startMemState, &endMemState );
+		_CrtMemDumpStatistics( &diffMemState );
+	#endif
+
+	printf ("\nPass %d, Fail %d\n", gPass, gFail);
+
+	return gFail;
+}


### PR DESCRIPTION
Include tinyxml2 3.0.0 and use it by default.  The option USE_INTERNAL_TINYXML can be set OFF to use an installed version instead.

Change encfs to build statically by default, which simplifies dependencies of resulting executable.  The option BUILD_SHARED_LIBS can be set ON to build using a shared library.