### PR TITLE
Filenode cache refactor

### DIFF
--- a/encfs/Context.cpp
+++ b/encfs/Context.cpp
@@ -127,14 +127,6 @@ void EncFS_Context::eraseNode(const char *path, FileNode *pl) {
 
   it->second.pop_front();
 
-  // if no more references to this file, remove the record all together
-  if (it->second.empty()) {
-    // attempts to make use of shallow copy to clear memory used to hold
-    // unencrypted filenames.. not sure this does any good..
-    std::string storedName = it->first;
-    openFiles.erase(it);
-    storedName.assign(storedName.length(), '\0');
-  }
 }
 
 }  // namespace encfs

--- a/encfs/Context.h
+++ b/encfs/Context.h
@@ -21,10 +21,10 @@
 #ifndef _Context_incl_
 #define _Context_incl_
 
+#include <forward_list>
 #include <memory>
 #include <pthread.h>
 #include <set>
-
 #include <string>
 #include <unordered_map>
 
@@ -42,15 +42,14 @@ class EncFS_Context {
   EncFS_Context();
   ~EncFS_Context();
 
-  std::shared_ptr<FileNode> getNode(void *ptr);
   std::shared_ptr<FileNode> lookupNode(const char *path);
 
   int getAndResetUsageCounter();
   int openFileCount() const;
 
-  void *putNode(const char *path, const std::shared_ptr<FileNode> &node);
+  FileNode *putNode(const char *path, std::shared_ptr<FileNode> &&node);
 
-  void eraseNode(const char *path, void *placeholder);
+  void eraseNode(const char *path, FileNode *fnode);
 
   void renameNode(const char *oldName, const char *newName);
 
@@ -81,13 +80,9 @@ class EncFS_Context {
    * release() is called.  std::shared_ptr then does our reference counting for
    * us.
    */
-  struct Placeholder {
-    std::shared_ptr<FileNode> node;
 
-    Placeholder(const std::shared_ptr<FileNode> &ptr) : node(ptr) {}
-  };
-
-  typedef std::unordered_map<std::string, std::set<Placeholder *> > FileMap;
+  typedef std::unordered_map<
+      std::string, std::forward_list<std::shared_ptr<FileNode>>> FileMap;
 
   mutable pthread_mutex_t contextMutex;
   FileMap openFiles;

--- a/encfs/DirNode.cpp
+++ b/encfs/DirNode.cpp
@@ -633,7 +633,6 @@ std::shared_ptr<FileNode> DirNode::renameNode(const char *from, const char *to,
 std::shared_ptr<FileNode> DirNode::findOrCreate(const char *plainName) {
   std::shared_ptr<FileNode> node;
   if (ctx) node = ctx->lookupNode(plainName);
-
   if (!node) {
     uint64_t iv = 0;
     string cipherName = naming->encodePath(plainName, &iv);
@@ -647,14 +646,11 @@ std::shared_ptr<FileNode> DirNode::findOrCreate(const char *plainName) {
 
   return node;
 }
-std::shared_ptr<FileNode> DirNode::lookupNode(const char *plainName,
-                                              const char *requestor) {
-  (void)requestor;
+
+shared_ptr<FileNode> DirNode::lookupNode(const char *plainName,
+                                         const char * /* requestor */) {
   Lock _lock(mutex);
-
-  std::shared_ptr<FileNode> node = findOrCreate(plainName);
-
-  return node;
+  return findOrCreate(plainName);
 }
 
 /*

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -866,9 +866,8 @@ static void selectBlockMAC(int *macBytes, int *macRandBytes, bool forceMac) {
           "performance but it also means [almost] any modifications or errors\n"
           "within a block will be caught and will cause a read error."));
   } else {
-    cout << "\n\n"
-         << _("You specified --require-macs.  "
-              "Enabling block authentication code headers...")
+    cout << "\n\n" << _("You specified --require-macs.  "
+                        "Enabling block authentication code headers...")
          << "\n\n";
     addMAC = true;
   }

--- a/encfs/encfsctl.cpp
+++ b/encfs/encfsctl.cpp
@@ -182,31 +182,27 @@ static int showInfo(int argc, char **argv) {
       return EXIT_FAILURE;
     case Config_V3:
       // xgroup(diag)
-      cout << "\n"
-           << autosprintf(_("Version 3 configuration; "
-                            "created by %s\n"),
-                          config->creator.c_str());
+      cout << "\n" << autosprintf(_("Version 3 configuration; "
+                                    "created by %s\n"),
+                                  config->creator.c_str());
       break;
     case Config_V4:
       // xgroup(diag)
-      cout << "\n"
-           << autosprintf(_("Version 4 configuration; "
-                            "created by %s\n"),
-                          config->creator.c_str());
+      cout << "\n" << autosprintf(_("Version 4 configuration; "
+                                    "created by %s\n"),
+                                  config->creator.c_str());
       break;
     case Config_V5:
       // xgroup(diag)
-      cout << "\n"
-           << autosprintf(_("Version 5 configuration; "
-                            "created by %s (revision %i)\n"),
-                          config->creator.c_str(), config->subVersion);
+      cout << "\n" << autosprintf(_("Version 5 configuration; "
+                                    "created by %s (revision %i)\n"),
+                                  config->creator.c_str(), config->subVersion);
       break;
     case Config_V6:
       // xgroup(diag)
-      cout << "\n"
-           << autosprintf(_("Version 6 configuration; "
-                            "created by %s (revision %i)\n"),
-                          config->creator.c_str(), config->subVersion);
+      cout << "\n" << autosprintf(_("Version 6 configuration; "
+                                    "created by %s (revision %i)\n"),
+                                  config->creator.c_str(), config->subVersion);
       break;
   }
 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -155,8 +155,7 @@ static void usage(const char *name) {
             "    encfs ~/.crypt ~/crypt\n"
             "\n")
        // xgroup(usage)
-       << _("For more information, see the man page encfs(1)") << "\n"
-       << endl;
+       << _("For more information, see the man page encfs(1)") << "\n" << endl;
 }
 
 static void FuseUsage() {


### PR DESCRIPTION
I've been working on a number of code refactoring's, this one is quite small and un-intrusive.

This simplifies the FileNode open file cache, removing PlaceHolder and the use of std::set.

The use of std::set here was redundant, the PlaceHolder pointer added was always new, guaranteeing its uniqueness.

PlaceHolder itself is an additional container which is unnecessary, simply store the shared_ptr in a list and pass the FileNode pointer directly to fuse