### PR TITLE
Fix undeeded string assignment in eraseNode

### DIFF
--- a/encfs/Context.cpp
+++ b/encfs/Context.cpp
@@ -129,11 +129,7 @@ void EncFS_Context::eraseNode(const char *path, FileNode *pl) {
 
   // if no more references to this file, remove the record all together
   if (it->second.empty()) {
-    // attempts to make use of shallow copy to clear memory used to hold
-    // unencrypted filenames.. not sure this does any good..
-    std::string storedName = it->first;
     openFiles.erase(it);
-    storedName.assign(storedName.length(), '\0');
   }
 }
 

--- a/encfs/Context.cpp
+++ b/encfs/Context.cpp
@@ -127,6 +127,14 @@ void EncFS_Context::eraseNode(const char *path, FileNode *pl) {
 
   it->second.pop_front();
 
+  // if no more references to this file, remove the record all together
+  if (it->second.empty()) {
+    // attempts to make use of shallow copy to clear memory used to hold
+    // unencrypted filenames.. not sure this does any good..
+    std::string storedName = it->first;
+    openFiles.erase(it);
+    storedName.assign(storedName.length(), '\0');
+  }
 }
 
 }  // namespace encfs


### PR DESCRIPTION
My previous commit, erroneously removed the erase of the unreferenced file.

This PR reverts that commit and removes string assignment.

This should fix  #170 