### PR TITLE
Bugfix: Segfault when running paranoid config in verbose mode

### DIFF
--- a/encfs/FileNode.cpp
+++ b/encfs/FileNode.cpp
@@ -100,7 +100,9 @@ static bool setIV(const std::shared_ptr<FileIO> &io, uint64_t iv) {
 bool FileNode::setName(const char *plaintextName_, const char *cipherName_,
                        uint64_t iv, bool setIVFirst) {
   // Lock _lock( mutex );
-  VLOG(1) << "calling setIV on " << cipherName_;
+  if (cipherName_)
+    VLOG(1) << "calling setIV on " << cipherName_;
+
   if (setIVFirst) {
     if (fsConfig->config->externalIVChaining && !setIV(io, iv)) return false;
 


### PR DESCRIPTION
When "external IV chaining" is enabled, cipherName_ parameter may be NULL, resulting in segfault in verbose log attempt