### PR TITLE
silence security-related warning in encfs/test.cpp

### DIFF
--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -522,8 +522,8 @@ tinyxml2::XMLElement *addEl<>(tinyxml2::XMLDocument &doc,
   return addEl(doc, parent, name, v.c_str());
 }
 
-tinyxml2::XMLDocument *writeV6Config(const EncFSConfig *cfg) {
-  tinyxml2::XMLDocument *docptr = new tinyxml2::XMLDocument();
+std::shared_ptr<tinyxml2::XMLDocument> writeV6Config(const EncFSConfig *cfg) {
+  std::shared_ptr<tinyxml2::XMLDocument> docptr (new tinyxml2::XMLDocument());
   tinyxml2::XMLDocument &doc = *docptr;
 
   // Various static tags are included to make the output compatible with
@@ -567,13 +567,13 @@ tinyxml2::XMLDocument *writeV6Config(const EncFSConfig *cfg) {
 }
 
 bool writeV6Config(FILE *configFile, const EncFSConfig *cfg) {
-  tinyxml2::XMLDocument *doc = writeV6Config(cfg);
+  std::shared_ptr<tinyxml2::XMLDocument> doc (writeV6Config(cfg));
   auto err = doc->SaveFile(configFile, false);
   return err == tinyxml2::XML_SUCCESS;
 }
 
 bool writeV6Config(const char *configFile, const EncFSConfig *cfg) {
-  tinyxml2::XMLDocument *doc = writeV6Config(cfg);
+  std::shared_ptr<tinyxml2::XMLDocument> doc (writeV6Config(cfg));
   auto err = doc->SaveFile(configFile, false);
   return err == tinyxml2::XML_SUCCESS;
 }

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -270,7 +270,7 @@ bool readV6Config(XmlReader *rdr, EncFSConfig *cfg, struct ConfigInfo *) {
     config = (*serialization)["config"];
   }
   if (!config) {
-    RLOG(ERROR) << "Unable to find XML configuration in config file ";;
+    RLOG(ERROR) << "Unable to find XML configuration in config file";
     return false;
   }
 

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -522,8 +522,8 @@ tinyxml2::XMLElement *addEl<>(tinyxml2::XMLDocument &doc,
   return addEl(doc, parent, name, v.c_str());
 }
 
-std::shared_ptr<tinyxml2::XMLDocument> writeV6Config(const EncFSConfig *cfg) {
-  std::shared_ptr<tinyxml2::XMLDocument> docptr (new tinyxml2::XMLDocument());
+std::unique_ptr<tinyxml2::XMLDocument> writeV6Config(const EncFSConfig *cfg) {
+  std::unique_ptr<tinyxml2::XMLDocument> docptr (new tinyxml2::XMLDocument());
   tinyxml2::XMLDocument &doc = *docptr;
 
   // Various static tags are included to make the output compatible with
@@ -567,13 +567,13 @@ std::shared_ptr<tinyxml2::XMLDocument> writeV6Config(const EncFSConfig *cfg) {
 }
 
 bool writeV6Config(FILE *configFile, const EncFSConfig *cfg) {
-  std::shared_ptr<tinyxml2::XMLDocument> doc (writeV6Config(cfg));
+  std::unique_ptr<tinyxml2::XMLDocument> doc (writeV6Config(cfg));
   auto err = doc->SaveFile(configFile, false);
   return err == tinyxml2::XML_SUCCESS;
 }
 
 bool writeV6Config(const char *configFile, const EncFSConfig *cfg) {
-  std::shared_ptr<tinyxml2::XMLDocument> doc (writeV6Config(cfg));
+  std::unique_ptr<tinyxml2::XMLDocument> doc (writeV6Config(cfg));
   auto err = doc->SaveFile(configFile, false);
   return err == tinyxml2::XML_SUCCESS;
 }

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -148,7 +148,10 @@ bool writeV5Config(const char *configFile, const EncFSConfig *config);
 
 bool readV6Config(const char *configFile, EncFSConfig *config,
                   struct ConfigInfo *);
+bool readV6Config(FILE *configFile, EncFSConfig *config,
+                  struct ConfigInfo *);
 bool writeV6Config(const char *configFile, const EncFSConfig *config);
+bool writeV6Config(FILE *configFile, const EncFSConfig *config);
 
 }  // namespace encfs
 

--- a/encfs/XmlReader.cpp
+++ b/encfs/XmlReader.cpp
@@ -171,6 +171,13 @@ bool XmlReader::load(const char *fileName) {
   return err == tinyxml2::XML_SUCCESS;
 }
 
+bool XmlReader::load(FILE *file) {
+  pd->doc.reset(new tinyxml2::XMLDocument());
+
+  auto err = pd->doc->LoadFile(file);
+  return err == tinyxml2::XML_SUCCESS;
+}
+
 XmlValuePtr XmlReader::operator[](const char *name) const {
   tinyxml2::XMLNode *node = pd->doc->FirstChildElement(name);
   if (node == NULL) {

--- a/encfs/XmlReader.h
+++ b/encfs/XmlReader.h
@@ -64,6 +64,7 @@ class XmlReader {
   ~XmlReader();
 
   bool load(const char *fileName);
+  bool load(FILE *file);
 
   XmlValuePtr operator[](const char *name) const;
 

--- a/encfs/test.cpp
+++ b/encfs/test.cpp
@@ -176,24 +176,20 @@ bool runTests(const std::shared_ptr<Cipher> &cipher, bool verbose) {
 
     // save config
     //Creation of a temporary file should be more platform independent. On c++17 we could use std::filesystem.
-    string name = "/tmp/encfstestXXXXXX";
-    int tmpFd = mkstemp(&name[0]);
-    rAssert(-1 != tmpFd);
-    //mkstemp opens the temporary file, but we only need its name -> close it
-    rAssert(0 == close(tmpFd));
+    FILE *cfgFile = std::tmpfile();
     {
-      auto ok = writeV6Config(name.c_str(), &cfg);
+      auto ok = writeV6Config(cfgFile, &cfg);
       rAssert(ok == true);
     }
 
     // read back in and check everything..
     EncFSConfig cfg2;
     {
-      auto ok = readV6Config(name.c_str(), &cfg2, nullptr);
+      auto ok = readV6Config(cfgFile, &cfg2, nullptr);
       rAssert(ok == true);
     }
-    //delete the temporary file where we stored the config
-    rAssert(0 == unlink(name.c_str()));
+    //close the temporary file where we stored the config
+    rAssert(0 == fclose(cfgFile));
     
     // check..
     rAssert(cfg.cipherIface.implements(cfg2.cipherIface));


### PR DESCRIPTION
Hi, I was working in issue #200 but I see that it is already fixed by using mkstemp. Anyway here it is my version using std::tmpfile() which has the advantage of not requiring to unlink the temporary file and that it is more standard (and cross platform) than mkstemp.
