### PR TITLE
remove usage of deprecated RAND_pseudo_bytes

### DIFF
--- a/encfs/SSL_Cipher.cpp
+++ b/encfs/SSL_Cipher.cpp
@@ -488,19 +488,15 @@ static uint64_t _checksum_64(SSLKey *key, const unsigned char *data,
 /**
  * Write "len" bytes of random data into "buf"
  *
- * See "man 3 RAND_bytes" for the effect of strongRandom
+ * We ignore the @strongRandom parameter because OpenSSL
+ * does not * offer a "weak" random generator
  */
 bool SSL_Cipher::randomize(unsigned char *buf, int len,
-                           bool strongRandom) const {
+                           bool /*strongRandom*/) const {
   // to avoid warnings of uninitialized data from valgrind
   memset(buf, 0, len);
-  int result;
-  if (strongRandom) {
-    result = RAND_bytes(buf, len);
-  } else {
-    result = RAND_pseudo_bytes(buf, len);
-  }
 
+  int result = RAND_bytes(buf, len);
   if (result != 1) {
     char errStr[120];  // specs require string at least 120 bytes long..
     unsigned long errVal = 0;


### PR DESCRIPTION
OpenSSL 1.1 deprecated RAND_pseudo_bytes because RAND_bytes behave practically the same, except that "one will add an error to the error queue with insufficient entropy whilst the other will not" [1]. And we already manage the error queue properly, so we can remove it.

This commit removes a deprecated warning during building with OpenSSL 1.1

[1] https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=302d38e3f73d5fd2ba2fd30bb7798778cb9f18dd
