### PR TITLE
Fix a segfault when password is zero length.

### DIFF
--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -956,7 +956,9 @@ RootPtr createV6Config(EncFS_Context *ctx,
   const std::string passwordProgram = opts->passwordProgram;
   bool useStdin = opts->useStdin;
   bool reverseEncryption = opts->reverseEncryption;
-  ConfigMode configMode = opts->configMode;
+  ConfigMode configMode = (useStdin &&
+                           opts->configMode == Config_Prompt) ? Config_Standard
+                                                              : opts->configMode;
   bool annotate = opts->annotate;
 
   RootPtr rootInfo;
@@ -1168,6 +1170,9 @@ RootPtr createV6Config(EncFS_Context *ctx,
     userKey = config->getUserKey(passwordProgram, rootDir);
   else
     userKey = config->getNewUserKey();
+
+  if (userKey == nullptr)
+    return rootInfo;
 
   cipher->writeKey(volumeKey, encodedKey, userKey);
   userKey.reset();


### PR DESCRIPTION
This patch fixes the issues in #241.

* Added a missing `nullptr` check on `userKey`

* If `useStdin` and `configMode == Config_Prompt` then default to `Config_Standard`,
   otherwise we might read the password input instead on the config mode.

I'm not sure if setting `Config_Standard` as a default option like this is the best course of action.