### PR TITLE
Suggest "$@", not $*, in documentation

### DIFF
--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -182,7 +182,7 @@ Note that encfs arguments cannot be set this way.  If you need to set encfs
 arguments, create a wrapper, such as  encfs-reverse;
 
     #!/bin/sh
-    encfs --reverse $*
+    encfs --reverse "$@"
 
 Then mount using the script path
 


### PR DESCRIPTION
`$*` operates by:

- Concatenating all arguments with the first character in `IFS` (by default a space) into a single string
- Splitting that string on all characters found in `IFS` to join a list of words
- Expanding each of those words as a glob character

Thus, using `$*` in a wrapper means that an argument such as `"one word"` becomes two arguments, `one` and `word`, and an argument `'*.txt'` can be replaced with an entirely unknown number of arguments (ie. `one.txt`, `two.txt`, if multiple matches exist in the current directory) despite its quoting.

Use `"$@"` to pass an argument vector through literally without any kind of expansion.