### PR TITLE
Improve auto unmount

### DIFF
--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -768,7 +768,7 @@ static bool unmountFS(EncFS_Context *ctx) {
     else
       rc = system(("/sbin/umount "+std::string(arg->opts->mountPoint)).c_str());
     if (!rc) {
-      RLOG(WARNING) << "Filesystem inactive, unmounted: " << arg->opts->mountPoint;
+      RLOG(INFO) << "Filesystem inactive, unmounted: " << arg->opts->mountPoint;
       return true;
     }
     else {

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -729,9 +729,8 @@ static void *idleMonitor(void *_arg) {
           break;
         }
       } else {
-        RLOG(WARNING) << "Filesystem " << arg->opts->mountPoint
-                      << " inactive, but still " << openCount
-                      << " opened files";
+        RLOG(WARNING) << "Filesystem inactive, but " << openCount
+                      << " files opened: " << arg->opts->mountPoint;
       }
     }
 
@@ -769,13 +768,11 @@ static bool unmountFS(EncFS_Context *ctx) {
     else
       rc = system(("/sbin/umount "+std::string(arg->opts->mountPoint)).c_str());
     if (!rc) {
-      RLOG(WARNING) << "Filesystem " << arg->opts->mountPoint
-                    << " inactive, unmounted";
+      RLOG(WARNING) << "Filesystem inactive, unmounted: " << arg->opts->mountPoint;
       return true;
     }
     else {
-      RLOG(ERROR) << "Filesystem " << arg->opts->mountPoint
-                  << " inactive, but unmount failed";
+      RLOG(ERROR) << "Filesystem inactive, but unmount failed: " << arg->opts->mountPoint;
       return false;
     }
   }

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -730,7 +730,7 @@ static void *idleMonitor(void *_arg) {
         }
       } else {
         RLOG(WARNING) << "Filesystem " << arg->opts->mountPoint
-                      << " inactivity detected, but still " << openCount
+                      << " inactive, but still " << openCount
                       << " opened files";
       }
     }
@@ -770,12 +770,12 @@ static bool unmountFS(EncFS_Context *ctx) {
       rc = system(("/sbin/umount "+std::string(arg->opts->mountPoint)).c_str());
     if (!rc) {
       RLOG(WARNING) << "Filesystem " << arg->opts->mountPoint
-                    << " inactivity detected, unmounted";
+                    << " inactive, unmounted";
       return true;
     }
     else {
       RLOG(ERROR) << "Filesystem " << arg->opts->mountPoint
-                  << " inactivity detected, but failed to unmount";
+                  << " inactive, but unmount failed";
       return false;
     }
   }


### PR DESCRIPTION
Hello,

Here is a PR to improve auto unmount.
It is now :
- more secure because encfs will not exit if unmount failed ;
- libfuse3 compatible because it does not use `fuse_unmount_compat22` anymore, which has been removed from libfuse3.

Thank you 👍 

Ben