### PR TITLE
Get idle counters at once

### DIFF
--- a/encfs/Context.cpp
+++ b/encfs/Context.cpp
@@ -74,20 +74,15 @@ void EncFS_Context::setRoot(const std::shared_ptr<DirNode> &r) {
 
 bool EncFS_Context::isMounted() { return root.get() != nullptr; }
 
-int EncFS_Context::getAndResetUsageCounter() {
+void EncFS_Context::getAndResetUsageCounter(int *usage, int *openCount) {
   Lock lock(contextMutex);
 
-  int count = usageCount;
+  *usage = usageCount;
   usageCount = 0;
 
-  return count;
+  *openCount = openFiles.size();
 }
 
-int EncFS_Context::openFileCount() const {
-  Lock lock(contextMutex);
-
-  return openFiles.size();
-}
 std::shared_ptr<FileNode> EncFS_Context::lookupNode(const char *path) {
   Lock lock(contextMutex);
 

--- a/encfs/Context.h
+++ b/encfs/Context.h
@@ -44,9 +44,8 @@ class EncFS_Context {
 
   std::shared_ptr<FileNode> lookupNode(const char *path);
 
-  int getAndResetUsageCounter();
-  int openFileCount() const;
-
+  void getAndResetUsageCounter(int *usage, int *openCount);
+  
   FileNode *putNode(const char *path, std::shared_ptr<FileNode> &&node);
 
   void eraseNode(const char *path, FileNode *fnode);

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -725,7 +725,7 @@ static void *idleMonitor(void *_arg) {
       ++idleCycles;
     else {
       if (idleCycles >= timeoutCycles)
-        RLOG(WARNING) << "Filesystem no more inactive: "
+        RLOG(WARNING) << "Filesystem no longer inactive: "
                       << arg->opts->mountPoint;
       idleCycles = 0;
     }

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -718,15 +718,19 @@ static void *idleMonitor(void *_arg) {
   pthread_mutex_lock(&ctx->wakeupMutex);
 
   while (ctx->running) {
-    int usage = ctx->getAndResetUsageCounter();
+    int usage, openCount;
+    ctx->getAndResetUsageCounter(&usage, &openCount);
 
     if (usage == 0 && ctx->isMounted())
       ++idleCycles;
-    else
+    else {
+      if (idleCycles >= timeoutCycles)
+        RLOG(WARNING) << "Filesystem " << arg->opts->mountPoint
+                      << " no more inactive"
       idleCycles = 0;
+    }
 
     if (idleCycles >= timeoutCycles) {
-      int openCount = ctx->openFileCount();
       if (openCount == 0) {
         if (unmountFS(ctx)) {
           // wait for main thread to wake us up

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -726,7 +726,7 @@ static void *idleMonitor(void *_arg) {
     else {
       if (idleCycles >= timeoutCycles)
         RLOG(WARNING) << "Filesystem " << arg->opts->mountPoint
-                      << " no more inactive"
+                      << " no more inactive";
       idleCycles = 0;
     }
 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -725,8 +725,8 @@ static void *idleMonitor(void *_arg) {
       ++idleCycles;
     else {
       if (idleCycles >= timeoutCycles)
-        RLOG(WARNING) << "Filesystem " << arg->opts->mountPoint
-                      << " no more inactive";
+        RLOG(WARNING) << "Filesystem no more inactive: "
+                      << arg->opts->mountPoint;
       idleCycles = 0;
     }
 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -725,8 +725,8 @@ static void *idleMonitor(void *_arg) {
       ++idleCycles;
     else {
       if (idleCycles >= timeoutCycles)
-        RLOG(WARNING) << "Filesystem no longer inactive: "
-                      << arg->opts->mountPoint;
+        RLOG(INFO) << "Filesystem no longer inactive: "
+                   << arg->opts->mountPoint;
       idleCycles = 0;
     }
 


### PR DESCRIPTION
Hello,

Here is a PR which get both idle counters (`usage` & `openCount`) at once.
It avoids the following race :
- get `usage`, returns 0
- _a file is opened_
- get `openCount`, returns 1
- then display _inactivity detected, but still X opened files_, whereas FS is no more inactive...

Thank you 👍 

Ben