### PR TITLE
Return errno in case of write failed

### DIFF
--- a/encfs/BlockFileIO.h
+++ b/encfs/BlockFileIO.h
@@ -43,7 +43,7 @@ class BlockFileIO : public FileIO {
 
   // implemented in terms of blocks.
   virtual ssize_t read(const IORequest &req) const;
-  virtual bool write(const IORequest &req);
+  virtual int write(const IORequest &req);
 
   virtual int blockSize() const;
 
@@ -54,10 +54,10 @@ class BlockFileIO : public FileIO {
   // same as read(), except that the request.offset field is guarenteed to be
   // block aligned, and the request size will not be larger then 1 block.
   virtual ssize_t readOneBlock(const IORequest &req) const = 0;
-  virtual bool writeOneBlock(const IORequest &req) = 0;
+  virtual int writeOneBlock(const IORequest &req) = 0;
 
   ssize_t cacheReadOneBlock(const IORequest &req) const;
-  bool cacheWriteOneBlock(const IORequest &req);
+  int cacheWriteOneBlock(const IORequest &req);
 
   int _blockSize;
   bool _allowHoles;

--- a/encfs/CipherFileIO.cpp
+++ b/encfs/CipherFileIO.cpp
@@ -346,12 +346,12 @@ ssize_t CipherFileIO::readOneBlock(const IORequest &req) const {
   return readSize;
 }
 
-bool CipherFileIO::writeOneBlock(const IORequest &req) {
+int CipherFileIO::writeOneBlock(const IORequest &req) {
 
   if (haveHeader && fsConfig->reverseEncryption) {
     VLOG(1)
         << "writing to a reverse mount with per-file IVs is not implemented";
-    return false;
+    return -EPERM;
   }
 
   int bs = blockSize();
@@ -366,19 +366,20 @@ bool CipherFileIO::writeOneBlock(const IORequest &req) {
     ok = blockWrite(req.data, (int)req.dataLen, blockNum ^ fileIV);
   }
 
+  int res = 0;
   if (ok) {
     if (haveHeader) {
       IORequest tmpReq = req;
       tmpReq.offset += HEADER_SIZE;
-      ok = base->write(tmpReq);
+      res = base->write(tmpReq);
     } else
-      ok = base->write(req);
+      res = base->write(req);
   } else {
     VLOG(1) << "encodeBlock failed for block " << blockNum << ", size "
             << req.dataLen;
-    ok = false;
+    res = -EIO;
   }
-  return ok;
+  return res;
 }
 
 bool CipherFileIO::blockWrite(unsigned char *buf, int size,

--- a/encfs/CipherFileIO.h
+++ b/encfs/CipherFileIO.h
@@ -65,7 +65,7 @@ class CipherFileIO : public BlockFileIO {
 
  private:
   virtual ssize_t readOneBlock(const IORequest &req) const;
-  virtual bool writeOneBlock(const IORequest &req);
+  virtual int writeOneBlock(const IORequest &req);
   virtual void generateReverseHeader(unsigned char *data);
 
   void initHeader();

--- a/encfs/FileIO.h
+++ b/encfs/FileIO.h
@@ -68,7 +68,7 @@ class FileIO {
   virtual off_t getSize() const = 0;
 
   virtual ssize_t read(const IORequest &req) const = 0;
-  virtual bool write(const IORequest &req) = 0;
+  virtual int write(const IORequest &req) = 0;
 
   virtual int truncate(off_t size) = 0;
 

--- a/encfs/FileNode.cpp
+++ b/encfs/FileNode.cpp
@@ -209,7 +209,7 @@ ssize_t FileNode::read(off_t offset, unsigned char *data, ssize_t size) const {
   return io->read(req);
 }
 
-bool FileNode::write(off_t offset, unsigned char *data, ssize_t size) {
+int FileNode::write(off_t offset, unsigned char *data, ssize_t size) {
   VLOG(1) << "FileNode::write offset " << offset << ", data size " << size;
 
   IORequest req;

--- a/encfs/FileNode.h
+++ b/encfs/FileNode.h
@@ -68,7 +68,7 @@ class FileNode {
   off_t getSize() const;
 
   ssize_t read(off_t offset, unsigned char *data, ssize_t size) const;
-  bool write(off_t offset, unsigned char *data, ssize_t size);
+  int write(off_t offset, unsigned char *data, ssize_t size);
 
   // truncate the file to a particular size
   int truncate(off_t size);

--- a/encfs/MACFileIO.cpp
+++ b/encfs/MACFileIO.cpp
@@ -208,7 +208,7 @@ ssize_t MACFileIO::readOneBlock(const IORequest &req) const {
   return readSize;
 }
 
-bool MACFileIO::writeOneBlock(const IORequest &req) {
+int MACFileIO::writeOneBlock(const IORequest &req) {
   int headerSize = macBytes + randBytes;
 
   int bs = blockSize() + headerSize;
@@ -225,7 +225,7 @@ bool MACFileIO::writeOneBlock(const IORequest &req) {
   memcpy(newReq.data + headerSize, req.data, req.dataLen);
   if (randBytes > 0) {
     if (!cipher->randomize(newReq.data + macBytes, randBytes, false))
-      return false;
+      return -EIO;
   }
 
   if (macBytes > 0) {
@@ -240,11 +240,11 @@ bool MACFileIO::writeOneBlock(const IORequest &req) {
   }
 
   // now, we can let the next level have it..
-  bool ok = base->write(newReq);
+  int res = base->write(newReq);
 
   MemoryPool::release(mb);
 
-  return ok;
+  return res;
 }
 
 int MACFileIO::truncate(off_t size) {

--- a/encfs/MACFileIO.h
+++ b/encfs/MACFileIO.h
@@ -64,7 +64,7 @@ class MACFileIO : public BlockFileIO {
 
  private:
   virtual ssize_t readOneBlock(const IORequest &req) const;
-  virtual bool writeOneBlock(const IORequest &req);
+  virtual int writeOneBlock(const IORequest &req);
 
   std::shared_ptr<FileIO> base;
   std::shared_ptr<Cipher> cipher;

--- a/encfs/RawFileIO.cpp
+++ b/encfs/RawFileIO.cpp
@@ -219,7 +219,7 @@ int RawFileIO::write(const IORequest &req) {
   while (bytes && retrys > 0) {
     errno = 0;
     ssize_t writeSize = ::pwrite(fd, buf, bytes, offset);
-    eno=errno;
+    eno = errno;
 
     if (writeSize < 0) {
       knownSize = false;

--- a/encfs/RawFileIO.cpp
+++ b/encfs/RawFileIO.cpp
@@ -220,8 +220,13 @@ bool RawFileIO::write(const IORequest &req) {
 
     if (writeSize < 0) {
       knownSize = false;
-      RLOG(WARNING) << "write failed at offset " << offset << " for " << bytes
-                    << " bytes: " << strerror(errno);
+      //RLOG(WARNING) << "write failed at offset " << offset << " for " << bytes
+      //              << " bytes: " << strerror(errno);
+      // /!\ Strangely RLOG modifies errno to "Permission denied" !
+      // So here is a crappy workaround, and this issue could be present somewhere else in the code !
+      VLOG(1) << "write failed at offset " << offset << " for " << bytes
+              << " bytes: " << strerror(errno);
+      
       return false;
     }
 

--- a/encfs/RawFileIO.h
+++ b/encfs/RawFileIO.h
@@ -46,7 +46,7 @@ class RawFileIO : public FileIO {
   virtual off_t getSize() const;
 
   virtual ssize_t read(const IORequest &req) const;
-  virtual bool write(const IORequest &req);
+  virtual int write(const IORequest &req);
 
   virtual int truncate(off_t size);
 

--- a/encfs/encfs.cpp
+++ b/encfs/encfs.cpp
@@ -619,10 +619,11 @@ int encfs_fsync(const char *path, int dataSync, struct fuse_file_info *file) {
 }
 
 int _do_write(FileNode *fnode, unsigned char *ptr, size_t size, off_t offset) {
-  if (fnode->write(offset, ptr, size))
+  int res = fnode->write(offset, ptr, size);
+  if (!res)
     return size;
   else
-    return -errno;
+    return res;
 }
 
 int encfs_write(const char *path, const char *buf, size_t size, off_t offset,

--- a/encfs/encfs.cpp
+++ b/encfs/encfs.cpp
@@ -622,7 +622,7 @@ int _do_write(FileNode *fnode, unsigned char *ptr, size_t size, off_t offset) {
   if (fnode->write(offset, ptr, size))
     return size;
   else
-    return -EIO;
+    return -errno;
 }
 
 int encfs_write(const char *path, const char *buf, size_t size, off_t offset,


### PR DESCRIPTION
Hello,

This PR solves #272.

Strangely, I noticed that `RLOG` was modifying `errno` so that it was impossible to rely on this value right after in the code.
In my tests, `errno`, which was expected to be `EDQUOT`, was set to `EACCES` right after `RLOG` call.

**We may deeper analysis this sort of bug, as it may have side effects somewhere else in the code.**
(see #276 for this)

Thank you 👍 

Ben