### PR TITLE
Revert "-S" ABI change

### DIFF
--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -956,9 +956,7 @@ RootPtr createV6Config(EncFS_Context *ctx,
   const std::string passwordProgram = opts->passwordProgram;
   bool useStdin = opts->useStdin;
   bool reverseEncryption = opts->reverseEncryption;
-  ConfigMode configMode = (useStdin &&
-                           opts->configMode == Config_Prompt) ? Config_Standard
-                                                              : opts->configMode;
+  ConfigMode configMode = opts->configMode;
   bool annotate = opts->annotate;
 
   RootPtr rootInfo;
@@ -1170,9 +1168,6 @@ RootPtr createV6Config(EncFS_Context *ctx,
     userKey = config->getUserKey(passwordProgram, rootDir);
   else
     userKey = config->getNewUserKey();
-
-  if (userKey == nullptr)
-    return rootInfo;
 
   cipher->writeKey(volumeKey, encodedKey, userKey);
   userKey.reset();

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -1348,6 +1348,11 @@ CipherKey EncFSConfig::makeKey(const char *password, int passwdLen) {
   CipherKey userKey;
   std::shared_ptr<Cipher> cipher = getCipher();
 
+  if (passwdLen == 0) {
+    cerr << _("fatal: zero-length passwords are not allowed\n");
+    exit(1);
+  }
+
   // if no salt is set and we're creating a new password for a new
   // FS type, then initialize salt..
   if (salt.size() == 0 && kdfIterations == 0 && cfgType >= Config_V6) {
@@ -1389,10 +1394,12 @@ CipherKey EncFSConfig::getUserKey(bool useStdin) {
   }
 
   CipherKey userKey;
-  if (!res)
-    cerr << _("Zero length password not allowed\n");
-  else
+  if (!res) {
+    cerr << _("fatal: error reading password\n");
+    exit(1);
+  } else {
     userKey = makeKey(passBuf, strlen(passBuf));
+  }
 
   memset(passBuf, 0, sizeof(passBuf));
 


### PR DESCRIPTION
Revert c3a7da5eff4055e77dc9404b0c15945485232bf2 and enforce empty password ban.

Context: https://github.com/tomm/cryptkeeper/issues/23 https://github.com/vgough/encfs/issues/280