### PR TITLE
Turn on all integration tests in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 
-sudo: false
+sudo: true
 
 compiler:
   - clang
@@ -18,12 +18,13 @@ env:
    - secure: "KuAAwjiIqkk4vqSX/M3ZZIvQs6edm+tV8IADiklTUYZIFyxu8FgZ6RbDdMD2sef5bNZA1OZhlcbeRtiKff5CfMtvzc607Lg3NUkpi+ShMynWgqS/e0uCMf9ogEJlUiZMxf4juBi7v6DyMl/WV6pAdJmdfHtzcj8GF2mgTfQjkO8="
 
 before_script:
+  - sudo modprobe fuse
   - mkdir build
   - cd build
   - cmake ..
 
 script:
-  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then make && ./checkops ; fi
+  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then make && ./checkops && cd .. && ./test.sh ; fi
 
 addons:
   coverity_scan:
@@ -41,5 +42,5 @@ addons:
     packages:
       - clang
       - cmake
+      - fuse
       - libfuse-dev
-


### PR DESCRIPTION
I'm hoping to file a bug fix in the next several days for #247 and #283, and so I thought it would be a good idea to get not only [the CPP code tests](https://github.com/vgough/encfs/blob/master/encfs/test.cpp) executing in travis CI builds, but also all of [the Perl integration tests](https://github.com/vgough/encfs/tree/master/tests) as well. This should help to prevent regressions with future code changes. For instance, in my fix for #247 and #283 I'll likely add a new regression test into that suite.

I did have to turn `sudo` mode on to do this, so that `fuse` can be initialized. However, the remainder of the build was untouched and still runs fine. It also still runs in under 90 seconds :)

Also there are two newlines at the end of the travis config file; I removed one of them so now there is only one.