### PR TITLE
Change Spanish initials to English in es_ES.po

### DIFF
--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -469,7 +469,7 @@ msgstr ""
 
 #, c-format
 msgid "The directory \"%s\" does not exist. Should it be created? (y,n) "
-msgstr "El directorio \"%s\" no existe. ¿Deberia ser creado? (s,n) "
+msgstr "El directorio \"%s\" no existe. ¿Deberia ser creado? (y,n) "
 
 msgid ""
 "The external initialization-vector chaining option has been\n"


### PR DESCRIPTION
Change 's' to 'y' when asked to create a directory if it does not already exist.
It made no sense to keep Spanish initials, since the program has the English ones hardcoded. Previously the user would get an error message with no information about the problem, until they figured out that they should have used English initials.