### PR TITLE
Improve auto unmount

### DIFF
--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -43,11 +43,6 @@
 #include "i18n.h"
 #include "openssl.h"
 
-// Fuse version >= 26 requires another argument to fuse_unmount, which we
-// don't have.  So use the backward compatible call instead..
-extern "C" void fuse_unmount_compat22(const char *mountpoint);
-#define fuse_unmount fuse_unmount_compat22
-
 /* Arbitrary identifiers for long options that do
  * not have a short version */
 #define LONG_OPT_ANNOTATE 513
@@ -715,6 +710,11 @@ static void *idleMonitor(void *_arg) {
   const int timeoutCycles = 60 * arg->idleTimeout / ActivityCheckInterval;
   int idleCycles = -1;
 
+  bool unmountres = false;
+
+  // We will notify when FS will be unmounted, so notify that it has just been mounted
+  RLOG(INFO) << "Filesystem mounted: " << arg->opts->mountPoint;
+
   pthread_mutex_lock(&ctx->wakeupMutex);
 
   while (ctx->running) {
@@ -728,15 +728,15 @@ static void *idleMonitor(void *_arg) {
     if (idleCycles >= timeoutCycles) {
       int openCount = ctx->openFileCount();
       if (openCount == 0) {
-        if (unmountFS(ctx)) {
+        unmountres = unmountFS(ctx);
+        if (unmountres) {
           // wait for main thread to wake us up
           pthread_cond_wait(&ctx->wakeupCond, &ctx->wakeupMutex);
           break;
         }
       } else {
-        RLOG(WARNING) << "Filesystem " << arg->opts->mountPoint
-                      << " inactivity detected, but still " << openCount
-                      << " opened files";
+        RLOG(WARNING) << "Filesystem inactive, but " << openCount
+                      << " files opened: " << arg->opts->mountPoint;
       }
     }
 
@@ -753,6 +753,10 @@ static void *idleMonitor(void *_arg) {
 
   pthread_mutex_unlock(&ctx->wakeupMutex);
 
+  // If we are here FS has been unmounted, so if we did not unmount ourselves (manual, kill...), notify
+  if (!unmountres)
+    RLOG(INFO) << "Filesystem unmounted: " << arg->opts->mountPoint;
+
   VLOG(1) << "Idle monitoring thread exiting";
 
   return 0;
@@ -768,9 +772,13 @@ static bool unmountFS(EncFS_Context *ctx) {
     return false;
   } else {
     // Time to unmount!
-    RLOG(WARNING) << "Unmounting filesystem due to inactivity: "
-                  << arg->opts->mountPoint;
-    fuse_unmount(arg->opts->mountPoint.c_str());
+#if FUSE_USE_VERSION < 30
+    fuse_unmount(arg->opts->mountPoint.c_str(), NULL);
+#else
+    fuse_unmount(fuse_get_context()->fuse);
+#endif
+    // fuse_unmount succeeds and returns void
+    RLOG(INFO) << "Filesystem inactive, unmounted: " << arg->opts->mountPoint;
     return true;
   }
 }


### PR DESCRIPTION
Hello,

Here is a PR to improve auto unmount.

It does not use `fuse_unmount_compat22` anymore, which :
- has been removed from libfuse3 ;
- has some issues under FreeBSD.

Thank you 👍 

Ben