### PR TITLE
Correctly detect attr binary during tests

### DIFF
--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -252,7 +252,7 @@ static bool processArgs(int argc, char *argv[],
     // 'o' : arguments meant for fuse
     // 't' : syslog tag
     int res =
-        getopt_long(argc, argv, "HsSfvdmi:o:t:", long_options, &option_index);
+        getopt_long(argc, argv, "HsSfvdmi:o:t:V", long_options, &option_index);
 
     if (res == -1) break;
 
@@ -362,6 +362,9 @@ static bool processArgs(int argc, char *argv[],
       case 'V':
         // xgroup(usage)
         cerr << autosprintf(_("encfs version %s"), VERSION) << endl;
+#if defined(HAVE_XATTR)
+        cerr << "Compiled with : HAVE_XATTR" << endl;
+#endif
         exit(EXIT_SUCCESS);
         break;
       case 'H':
@@ -391,7 +394,7 @@ static bool processArgs(int argc, char *argv[],
     out->opts->mountPoint = slashTerminate(argv[optind++]);
   } else {
     // no mount point specified
-    cerr << _("Missing one or more arguments, aborting.");
+    cerr << _("Missing one or more arguments, aborting.") << endl;
     return false;
   }
 
@@ -474,13 +477,13 @@ static bool processArgs(int argc, char *argv[],
   if (!isDirectory(out->opts->rootDir.c_str()) &&
       !userAllowMkdir(out->opts->annotate ? 1 : 0, out->opts->rootDir.c_str(),
                       0700)) {
-    cerr << _("Unable to locate root directory, aborting.");
+    cerr << _("Unable to locate root directory, aborting.") << endl;
     return false;
   }
   if (!isDirectory(out->opts->mountPoint.c_str()) &&
       !userAllowMkdir(out->opts->annotate ? 2 : 0,
                       out->opts->mountPoint.c_str(), 0700)) {
-    cerr << _("Unable to locate mount point, aborting.");
+    cerr << _("Unable to locate mount point, aborting.") << endl;
     return false;
   }
 
@@ -537,6 +540,7 @@ int main(int argc, char *argv[]) {
     encfsArgs->fuseArgv[i] = NULL;  // libfuse expects null args..
 
   if (argc == 1 || !processArgs(argc, argv, encfsArgs)) {
+    cerr << endl;
     usage(argv[0]);
     return EXIT_FAILURE;
   }

--- a/tests/reverse.t.pl
+++ b/tests/reverse.t.pl
@@ -13,6 +13,22 @@ require("tests/common.pl");
 
 my $tempDir = $ENV{'TMPDIR'} || "/tmp";
 
+# Find attr binary
+my @binattr = ("attr", "-l");
+if(system("which xattr") == 0)
+{
+  @binattr = ("xattr", "-l");
+}
+if(system("which lsextattr") == 0)
+{
+  @binattr = ("lsextattr", "user");
+}
+if(system("./build/encfs -V 2>&1 | grep -q HAVE_XATTR") != 0)
+{
+  @binattr = ("ls", "-l"); //workaround for binaries without xattr support so that tests will not fail
+}
+
+
 # Helper function
 # Create a new empty working directory
 sub newWorkingDir
@@ -84,7 +100,7 @@ sub symlink_test
     $dec = readlink("$decrypted/symlink");
     ok( $dec eq $target, "symlink to '$target'") or
         print("# (original) $target' != '$dec' (decrypted)\n");
-    system("attr", "-l", "$decrypted/symlink");
+    system(@binattr, "$decrypted/symlink");
     my $return_code = $?;
     is($return_code, 0, "symlink to '$target' extended attributes can be read (return code was $return_code)");
     unlink("$plain/symlink");

--- a/tests/reverse.t.pl
+++ b/tests/reverse.t.pl
@@ -17,15 +17,16 @@ my $tempDir = $ENV{'TMPDIR'} || "/tmp";
 my @binattr = ("attr", "-l");
 if(system("which xattr") == 0)
 {
-  @binattr = ("xattr", "-l");
+    @binattr = ("xattr", "-l");
 }
 if(system("which lsextattr") == 0)
 {
-  @binattr = ("lsextattr", "user");
+    @binattr = ("lsextattr", "user");
 }
 if(system("./build/encfs -V 2>&1 | grep -q HAVE_XATTR") != 0)
 {
-  @binattr = ("ls", "-l"); //workaround for binaries without xattr support so that tests will not fail
+    # Workaround for binaries without xattr support so that tests will not fail
+    @binattr = ("ls", "-l");
 }
 
 


### PR DESCRIPTION
Hello,

This issue should solve issue #329 as Mac OS uses `xattr` command instead of `attr`.

Ben