### PR TITLE
Accept netbsd's librefuse as a FUSE library

### DIFF
--- a/cmake/FindFUSE.cmake
+++ b/cmake/FindFUSE.cmake
@@ -13,8 +13,8 @@ if (APPLE)
     set (FUSE_NAMES libosxfuse.dylib fuse)
     set (FUSE_SUFFIXES osxfuse fuse)
 else (APPLE)
-    set (FUSE_NAMES fuse)
-    set (FUSE_SUFFIXES fuse)
+    set (FUSE_NAMES fuse refuse)
+    set (FUSE_SUFFIXES fuse refuse)
 endif (APPLE)
 
 # find includes


### PR DESCRIPTION
It works with one hack I'd rather not send :-).
That is likely because it's compatible with an older FUSE API.