### PR TITLE
Detect binaries without xattr support during tests

### DIFF
--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -245,7 +245,7 @@ static bool processArgs(int argc, char *argv[],
     // 'o' : arguments meant for fuse
     // 't' : syslog tag
     int res =
-        getopt_long(argc, argv, "HsSfvdmi:o:t:", long_options, &option_index);
+        getopt_long(argc, argv, "HsSfvdmi:o:t:V", long_options, &option_index);
 
     if (res == -1) break;
 
@@ -355,6 +355,9 @@ static bool processArgs(int argc, char *argv[],
       case 'V':
         // xgroup(usage)
         cerr << autosprintf(_("encfs version %s"), VERSION) << endl;
+#if defined(HAVE_XATTR)
+        cerr << "Compiled with : HAVE_XATTR" << endl;
+#endif
         exit(EXIT_SUCCESS);
         break;
       case 'H':

--- a/tests/reverse.t.pl
+++ b/tests/reverse.t.pl
@@ -26,6 +26,11 @@ if(system("which lsextattr > /dev/null 2>&1") == 0)
     # FreeBSD
     @binattr = ("lsextattr", "user");
 }
+if(system("./build/encfs -V 2>&1 | grep -q HAVE_XATTR") != 0)
+{
+    # Workaround for binaries without xattr support so that tests will not fail
+    @binattr = ("ls", "-l");
+}
 
 # Helper function
 # Create a new empty working directory


### PR DESCRIPTION
Hello,

This PR follows #330, it corrects reverse test so that it now detects if EncFS has been compiled with xattr support.
It then avoids to fail xattr tests if they are not supported.
This is the case with FreeBSD which uses different includes to support xattr, not yet implemented by encfs.

Thank you 👍 

Ben