### PR TITLE
Make all xattr operations on link themselves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,20 +93,6 @@ check_cxx_source_compiles ("#include <sys/types.h>
   int main() { getxattr(0,0,0,0,0,0); return 1; }
   " XATTR_ADD_OPT)
 
-# Check if xattr function llistxattr exists.
-include (CheckCXXSourceCompiles)
-if (XATTR_ADD_OPT)
-check_cxx_source_compiles ("#include <sys/types.h>
-  #include <sys/xattr.h>
-  int main() { llistxattr(0,0,0,0); return 1; }
-  " XATTR_LLIST)
-else (XATTR_ADD_OPT)
-check_cxx_source_compiles ("#include <sys/types.h>
-  #include <sys/xattr.h>
-  int main() { llistxattr(0,0,0); return 1; }
-  " XATTR_LLIST)
-endif (XATTR_ADD_OPT)
-
 # Check if we have some standard functions.
 include (CheckFuncs)
 check_function_exists_glibc (lchmod HAVE_LCHMOD)

--- a/encfs/encfs.cpp
+++ b/encfs/encfs.cpp
@@ -660,7 +660,7 @@ int encfs_statfs(const char *path, struct statvfs *st) {
 #ifdef XATTR_ADD_OPT
 int _do_setxattr(EncFS_Context *, const string &cyName, const char *name,
                  const char *value, size_t size, uint32_t pos) {
-  int options = 0;
+  int options = XATTR_NOFOLLOW;
   return ::setxattr(cyName.c_str(), name, value, size, pos, options);
 }
 int encfs_setxattr(const char *path, const char *name, const char *value,
@@ -673,7 +673,7 @@ int encfs_setxattr(const char *path, const char *name, const char *value,
 #else
 int _do_setxattr(EncFS_Context *, const string &cyName, const char *name,
                  const char *value, size_t size, int flags) {
-  return ::setxattr(cyName.c_str(), name, value, size, flags);
+  return ::lsetxattr(cyName.c_str(), name, value, size, flags);
 }
 int encfs_setxattr(const char *path, const char *name, const char *value,
                    size_t size, int flags) {
@@ -686,7 +686,7 @@ int encfs_setxattr(const char *path, const char *name, const char *value,
 #ifdef XATTR_ADD_OPT
 int _do_getxattr(EncFS_Context *, const string &cyName, const char *name,
                  void *value, size_t size, uint32_t pos) {
-  int options = 0;
+  int options = XATTR_NOFOLLOW;
   return ::getxattr(cyName.c_str(), name, value, size, pos, options);
 }
 int encfs_getxattr(const char *path, const char *name, char *value, size_t size,
@@ -698,7 +698,7 @@ int encfs_getxattr(const char *path, const char *name, char *value, size_t size,
 #else
 int _do_getxattr(EncFS_Context *, const string &cyName, const char *name,
                  void *value, size_t size) {
-  return ::getxattr(cyName.c_str(), name, value, size);
+  return ::lgetxattr(cyName.c_str(), name, value, size);
 }
 int encfs_getxattr(const char *path, const char *name, char *value,
                    size_t size) {
@@ -710,12 +710,9 @@ int encfs_getxattr(const char *path, const char *name, char *value,
 
 int _do_listxattr(EncFS_Context *, const string &cyName, char *list,
                   size_t size) {
-#ifndef XATTR_LLIST
-#define llistxattr listxattr
-#endif
 #ifdef XATTR_ADD_OPT
-  int options = 0;
-  int res = ::llistxattr(cyName.c_str(), list, size, options);
+  int options = XATTR_NOFOLLOW;
+  int res = ::listxattr(cyName.c_str(), list, size, options);
 #else
   int res = ::llistxattr(cyName.c_str(), list, size);
 #endif
@@ -729,10 +726,10 @@ int encfs_listxattr(const char *path, char *list, size_t size) {
 
 int _do_removexattr(EncFS_Context *, const string &cyName, const char *name) {
 #ifdef XATTR_ADD_OPT
-  int options = 0;
+  int options = XATTR_NOFOLLOW;
   int res = ::removexattr(cyName.c_str(), name, options);
 #else
-  int res = ::removexattr(cyName.c_str(), name);
+  int res = ::lremovexattr(cyName.c_str(), name);
 #endif
   return (res == -1) ? -errno : res;
 }

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -245,7 +245,7 @@ static bool processArgs(int argc, char *argv[],
     // 'o' : arguments meant for fuse
     // 't' : syslog tag
     int res =
-        getopt_long(argc, argv, "HsSfvdmi:o:t:", long_options, &option_index);
+        getopt_long(argc, argv, "HsSfvdmi:o:t:V", long_options, &option_index);
 
     if (res == -1) break;
 
@@ -355,6 +355,9 @@ static bool processArgs(int argc, char *argv[],
       case 'V':
         // xgroup(usage)
         cerr << autosprintf(_("encfs version %s"), VERSION) << endl;
+#if defined(HAVE_XATTR)
+        cerr << "Compiled with : HAVE_XATTR" << endl;
+#endif
         exit(EXIT_SUCCESS);
         break;
       case 'H':

--- a/tests/reverse.t.pl
+++ b/tests/reverse.t.pl
@@ -26,6 +26,12 @@ if(system("which lsextattr > /dev/null 2>&1") == 0)
     # FreeBSD
     @binattr = ("lsextattr", "-h", "user");
 }
+# Do we support xattr ?
+my $have_xattr = 1;
+if(system("./build/encfs -V 2>&1 | grep -q HAVE_XATTR") != 0)
+{
+    $have_xattr = 0;
+}
 
 # Helper function
 # Create a new empty working directory
@@ -98,8 +104,7 @@ sub symlink_test
     $dec = readlink("$decrypted/symlink");
     ok( $dec eq $target, "symlink to '$target'") or
         print("# (original) $target' != '$dec' (decrypted)\n");
-    system(@binattr, "$decrypted/symlink");
-    my $return_code = $?;
+    my $return_code = ($have_xattr) ? system(@binattr, "$decrypted/symlink") : 0;
     is($return_code, 0, "symlink to '$target' extended attributes can be read (return code was $return_code)");
     unlink("$plain/symlink");
 }

--- a/tests/reverse.t.pl
+++ b/tests/reverse.t.pl
@@ -19,12 +19,12 @@ my @binattr = ("attr", "-l");
 if(system("which xattr > /dev/null 2>&1") == 0)
 {
     # Mac OS X
-    @binattr = ("xattr", "-l");
+    @binattr = ("xattr", "-s");
 }
 if(system("which lsextattr > /dev/null 2>&1") == 0)
 {
     # FreeBSD
-    @binattr = ("lsextattr", "user");
+    @binattr = ("lsextattr", "-h", "user");
 }
 
 # Helper function


### PR DESCRIPTION
Hello,

This PR finishes works done in #287 making all xattr operations on links themselves instead of their targets.
It should also solve #341 using `XATTR_NOFOLLOW` Mac OS flag.

Thank you 👍 

Ben