### PR TITLE
travis ci: upgrade to trusty, use system cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: cpp
 
 sudo: true
@@ -18,12 +20,12 @@ env:
    - secure: "KuAAwjiIqkk4vqSX/M3ZZIvQs6edm+tV8IADiklTUYZIFyxu8FgZ6RbDdMD2sef5bNZA1OZhlcbeRtiKff5CfMtvzc607Lg3NUkpi+ShMynWgqS/e0uCMf9ogEJlUiZMxf4juBi7v6DyMl/WV6pAdJmdfHtzcj8GF2mgTfQjkO8="
 
 before_script:
-  - sh ci/install-cmake.sh
   - sudo modprobe fuse
   - mkdir build
   - cd build
-  - ../ci/cmake/bin/cmake --version
-  - ../ci/cmake/bin/cmake ..
+  - cmake --version
+  - cmake ..
+
 
 script:
   - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then make && make check ; fi
@@ -47,3 +49,4 @@ addons:
       - fuse
       - libfuse-dev
       - gettext
+      - cmake3

--- a/ci/install-cmake.sh
+++ b/ci/install-cmake.sh
@@ -1,7 +1,0 @@
-set -x
-set -e
-if [ ! -e ci/cmake/bin/cmake ]; then
-  #wget http://www.cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz
-  tar -xzf ci/cmake-3.0.2-Linux-x86_64.tar.gz
-  mv cmake-3.0.2-Linux-x86_64 ci/cmake
-fi


### PR DESCRIPTION
On July 18, Travis upgraded their default build VM
to Ubuntu Trusty. Trusty has cmake 3.5.1, which allows us to
drop our bundled version.

We explicitely set "dist: trusty" to prevent our build jobs
from being routed to an older build VM.