### PR TITLE
travis ci: enable gcc, call build.sh && test.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: true
 
 compiler:
   - clang
+  - gcc
 
 branches:
   only:
@@ -21,14 +22,10 @@ env:
 
 before_script:
   - sudo modprobe fuse
-  - mkdir build
-  - cd build
   - cmake --version
-  - cmake ..
-
 
 script:
-  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then make && make check ; fi
+  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then ./build.sh && ./test.sh && make check -C build ; fi
 
 addons:
   coverity_scan:

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,15 @@
-#!/bin/bash
+#!/bin/bash -eu
 
-set -eu
+# Make sure we are in the directory this script is in.
+cd "$(dirname "$0")"
 
-if [ ! -d build ]
+if [[ ! -d build ]]
 then
 	mkdir build
 	cd build
 	cmake ..
-else
-	cd build
+	cd ..
 fi
 
-make
+make -j2 -C build
 

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,16 @@
 #!/bin/bash -eu
 
-./build/checkops &> /dev/null
+# Make sure we are in the directory this script is in.
+cd "$(dirname "$0")"
 
+# Failed tests can leave dangling mounts behind.
 for i in $(mount | grep -e "/tmp/encfs-reverse-tests-\|/tmp/encfs-tests-" | cut -f3 -d" "); do
 	echo "Warning: unmounting leftover filesystem: $i"
-	fusermount -u $i
+	fusermount -u $i || true
 done
+
+# This is very noisy so run it silently at first. Run it again with
+# output if the first run fails.
+./build/checkops &> /dev/null || ./build/checkops
 
 perl -MTest::Harness -e '$$Test::Harness::debug=1; runtests @ARGV;' tests/*.t.pl


### PR DESCRIPTION
gcc is default compiler on most distributions, we should
also test with it.

build.sh exists and should be tested as well, so why not use
it in Travis.
test.sh outputs much more details than "make check", so
run it as well.

Additionally, make build.sh and test.sh work when called from
other directories.