### PR TITLE
Drop cmake test logic and just run test.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - cmake --version
 
 script:
-  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then ./build.sh && ./test.sh && make check -C build ; fi
+  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then ./build.sh && ./test.sh ; fi
 
 addons:
   coverity_scan:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,28 +233,5 @@ if (POD2MAN)
     DESTINATION share/man/man1)
 endif (POD2MAN)
 
-# Tests
-enable_testing()
+add_custom_target(test COMMAND ${CMAKE_CURRENT_LIST_DIR}/test.sh)
 
-if (CMAKE_CONFIGURATION_TYPES)
-    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-        --force-new-ctest-process --output-on-failure
-        --build-config "$<CONFIGURATION>")
-else()
-    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-        --force-new-ctest-process --output-on-failure)
-endif()
-
-add_test (NAME checkops
-          COMMAND checkops)
-
-find_program (PERL_PROGRAM perl)
-if (PERL_PROGRAM)
-  file(GLOB pl_test_files "tests/*.t.pl")
-  add_test (NAME scriptedtests
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-            COMMAND ${PERL_PROGRAM}
-               -MTest::Harness
-               -e "$$Test::Harness::verbose=1; runtests @ARGV;"
-               ${pl_test_files})
-endif (PERL_PROGRAM)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ Optional, but strongly recommended, is running the test suite
 to verify that the generated binaries work as expected
 (runtime: 20 seconds)
 
-    make check
+    make test
 
 The compilation process creates two executables, encfs and encfsctl in
 the encfs directory.  You can install to in a system directory via

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,8 @@ for i in $(mount | grep -e "/tmp/encfs-reverse-tests-\|/tmp/encfs-tests-" | cut 
 	fusermount -u $i || true
 done
 
+set -x
+
 # This is very noisy so run it silently at first. Run it again with
 # output if the first run fails.
 ./build/checkops &> /dev/null || ./build/checkops


### PR DESCRIPTION
We had the situation that "make test" runs the test suite but does not
show useful error messages (see
https://github.com/vgough/encfs/issues/358 for an example).

"make check" did the right thing by using the "--output-on-failure"
feature, but depended on "make test" being available as well. This
means users will continue to run "make test".

This commits drops the cmake test logic and adds a dumb "make test"
target that simply runs test.sh.