### PR TITLE
Correct build env

### DIFF
--- a/cmake/FindIntl.cmake
+++ b/cmake/FindIntl.cmake
@@ -1,3 +1,8 @@
+# This file comes from https://github.com/Kitware/CMake/blob/master/Modules/FindIntl.cmake
+# It is needed for cmake < 3.2.0 which does not have it.
+# When cmake 3.0.2 (Debian jessie version) will really be outdated, we will be able to
+# delete this file and bump cmake version in CMakeLists.txt and INSTALL.md.
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/test.sh
+++ b/test.sh
@@ -4,15 +4,24 @@
 cd "$(dirname "$0")"
 
 # Failed tests can leave dangling mounts behind.
-for i in $(mount | grep -e "/tmp/encfs-reverse-tests-\|/tmp/encfs-tests-" | cut -f3 -d" "); do
+todel+=("")
+for i in $(mount | grep "/tmp/encfs-tests-" | cut -f3 -d" "); do
 	echo "Warning: unmounting leftover filesystem: $i"
-	fusermount -u $i || true
+	if which fusermount >/dev/null 2>&1
+	then
+		fusermount -u $i || true
+	else
+		umount -f $i || true
+	fi
+	parent=$(echo $i | grep "/tmp/encfs-tests-" | sed 's+\(/tmp/encfs-tests-[^/]*\).*+\1+')
+	todel+=("$parent")
 done
+rm -rf ${todel[@]}
 
 set -x
 
 # This is very noisy so run it silently at first. Run it again with
 # output if the first run fails.
-./build/checkops &> /dev/null || ./build/checkops
+./build/checkops >/dev/null 2>&1 || ./build/checkops
 
 perl -MTest::Harness -e '$$Test::Harness::debug=1; runtests @ARGV;' tests/*.t.pl

--- a/tests/normal.t.pl
+++ b/tests/normal.t.pl
@@ -87,7 +87,7 @@ sub runTests
 # Create a new empty working directory
 sub newWorkingDir
 {
-    our $workingDir = mkdtemp("$tempDir/encfs-tests-XXXX")
+    our $workingDir = mkdtemp("$tempDir/encfs-tests-normal-XXXX")
         || BAIL_OUT("Could not create temporary directory");
 
     our $raw = "$workingDir/raw";

--- a/tests/reverse.t.pl
+++ b/tests/reverse.t.pl
@@ -43,7 +43,7 @@ if(system("./build/encfs --verbose --version 2>&1 | grep -q HAVE_XATTR") != 0)
 # Create a new empty working directory
 sub newWorkingDir
 {
-    our $workingDir = mkdtemp("$tempDir/encfs-reverse-tests-XXXX")
+    our $workingDir = mkdtemp("$tempDir/encfs-tests-reverse-XXXX")
         || BAIL_OUT("Could not create temporary directory");
 
     our $plain = "$workingDir/plain";


### PR DESCRIPTION
Hi,

This PR :
- adds a comment to `FindIntl.cmake` file to say why it is there ;
- removes temporary directories left by dangling mounts ;
- makes `test.sh` FreeBSD (and others) compatible (`fusermount` may not exist).

Thank you 👍 

Ben