### PR TITLE
Drop unmount logic from test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,15 +1,7 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 
 # Make sure we are in the directory this script is in.
 cd "$(dirname "$0")"
-
-# Failed tests can leave dangling mounts behind.
-for i in $(mount | grep -e "/tmp/encfs-reverse-tests-\|/tmp/encfs-tests-" | cut -f3 -d" "); do
-	echo "Warning: unmounting leftover filesystem: $i"
-	fusermount -u $i || true
-done
-
-set -x
 
 # This is very noisy so run it silently at first. Run it again with
 # output if the first run fails.


### PR DESCRIPTION
Unmounting leftover mounts is a convenience function for developers,
but it would need to be expanded to work on MacOS and FreeBSD, which
adds more complexity.

Let's keep test.sh at the bare minimum that is needed for its purpose:
running the tests.