### PR TITLE
replace most compile-time platform checks with build-time checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ if (APPLE)
    endif()
 endif()
 
+if (WIN32 OR APPLE)
+  set(DEFAULT_CASE_INSENSITIVE TRUE)
+else()
+  set(DEFAULT_CASE_INSENSITIVE FALSE)
+endif()
+
 # Check for FUSE.
 find_package (FUSE REQUIRED)
 include_directories (${FUSE_INCLUDE_DIR})
@@ -76,6 +82,9 @@ include (CheckIncludeFileCXX)
 check_include_file_cxx (attr/xattr.h HAVE_ATTR_XATTR_H)
 check_include_file_cxx (sys/xattr.h HAVE_SYS_XATTR_H)
 
+include(CheckStructHasMember)
+check_struct_has_member(dirent d_type dirent.h HAVE_DIRENT_D_TYPE LANGUAGE CXX)
+
 # Check if xattr functions take extra arguments, as they do on OSX.
 include (CheckCXXSourceCompiles)
 check_cxx_source_compiles ("#include <sys/types.h>
@@ -87,6 +96,7 @@ check_cxx_source_compiles ("#include <sys/types.h>
 include (CheckFuncs)
 check_function_exists_glibc (lchmod HAVE_LCHMOD)
 check_function_exists_glibc (utimensat HAVE_UTIMENSAT)
+check_function_exists_glibc (fdatasync HAVE_FDATASYNC)
 
 set (CMAKE_THREAD_PREFER_PTHREAD)
 find_package (Threads REQUIRED)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -6,6 +6,11 @@
 #cmakedefine XATTR_LLIST
 
 #cmakedefine HAVE_LCHMOD
+#cmakedefine HAVE_FDATASYNC
+
+#cmakedefine HAVE_DIRENT_D_TYPE
+
+#cmakedefine DEFAULT_CASE_INSENSITIVE
 
 /* TODO: add other thread library support. */
 #cmakedefine CMAKE_USE_PTHREADS_INIT

--- a/encfs/DirNode.cpp
+++ b/encfs/DirNode.cpp
@@ -72,7 +72,7 @@ static bool _nextName(struct dirent *&de, const std::shared_ptr<DIR> &dir,
 
   if (de != nullptr) {
     if (fileType != nullptr) {
-#if defined(_DIRENT_HAVE_D_TYPE) || defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(HAVE_DIRENT_D_TYPE)
       *fileType = de->d_type;
 #else
 #warning "struct dirent.d_type not supported"
@@ -430,7 +430,7 @@ bool DirNode::genRenameList(list<RenameEl> &renameList, const char *fromP,
       ren.newPName = string(toP) + '/' + plainName;
 
       bool isDir;
-#if defined(_DIRENT_HAVE_D_TYPE)
+#if defined(HAVE_DIRENT_D_TYPE)
       if (de->d_type != DT_UNKNOWN) {
         isDir = (de->d_type == DT_DIR);
       } else

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -1035,7 +1035,7 @@ RootPtr createV6Config(EncFS_Context *ctx,
     alg = findCipherAlgorithm("AES", keySize);
 
 // If case-insensitive system, opt for Block32 filename encoding
-#if defined(__APPLE__) || defined(WIN32)
+#if DEFAULT_CASE_INSENSITIVE
     nameIOIface = BlockNameIO::CurrentInterface(true);
 #else
     nameIOIface = BlockNameIO::CurrentInterface();

--- a/encfs/RawFileIO.cpp
+++ b/encfs/RawFileIO.cpp
@@ -257,9 +257,6 @@ int RawFileIO::truncate(off_t size) {
 
   if (fd >= 0 && canWrite) {
     res = ::ftruncate(fd, size);
-#if !defined(__FreeBSD__) && !defined(__APPLE__)
-    ::fdatasync(fd);
-#endif
   } else {
     res = ::truncate(name.c_str(), size);
   }
@@ -274,6 +271,14 @@ int RawFileIO::truncate(off_t size) {
     res = 0;
     fileSize = size;
     knownSize = true;
+  }
+
+  if (fd >= 0 && canWrite) {
+#if defined(HAVE_FDATASYNC)
+    ::fdatasync(fd);
+#else
+    ::fsync(fd);  
+#endif
   }
 
   return res;


### PR DESCRIPTION
Adds CMake check for dirent field, fdatasync function, and platforms where encfs should default to case-insensitive encoding.

