### PR TITLE
Re-enable integration tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - ./ci/setup.sh
 
 script:
-  - ./ci/check.sh
+  - ./ci/build.sh
 
 addons:
   apt:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,11 @@ Compiling EncFS
 
 EncFS uses the CMake toolchain to create makefiles.
 
-Steps to build EncFS:
+Quickest way to build and test EncFS :
+
+    ./build.sh
+
+Or following are the detailed steps to build EncFS:
 
     mkdir build
     cd build
@@ -29,11 +33,11 @@ encrypted filesystem and run tests on it:
     make integration
 
 The compilation process creates two executables, encfs and encfsctl in
-the encfs directory.  You can install to in a system directory via
+the encfs directory.  You can install to in a system directory via:
 
     make install
 
-. If the default path (`/usr/local`) is not where you want things
+If the default path (`/usr/local`) is not where you want things
 installed, then set the CMAKE_INSTALL_PREFIX option when running cmake.  Eg:
 
     cmake .. -DCMAKE_INSTALL_PREFIX=/opt/local

--- a/build.sh
+++ b/build.sh
@@ -12,4 +12,9 @@ then
 fi
 
 make -j2 -C build
+make test -C build
+make integration -C build
+
+echo
+echo 'Everything looks good, you can install via "make install -C build".'
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -16,6 +16,7 @@ cd build
 cmake .. ${CFG}
 make -j2
 make test
+make integration
 
 cd ..
 


### PR DESCRIPTION
This PR :
- re-enables integration tests in Travis ;
- adds tests to `build.sh` ;
- advices `build.sh` in `INSTALL.md` ;
- renames `ci/check.sh` to `ci/build.sh` for consistency.

Thank you 👍 