### PR TITLE
Add current path to perl integration tests

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -3,4 +3,4 @@
 # Make sure we are in the directory this script is in.
 cd "$(dirname "$0")"
 
-perl -MTest::Harness -e '$$Test::Harness::debug=1; runtests @ARGV;' integration/*.t.pl
+perl -I. -MTest::Harness -e '$$Test::Harness::debug=1; runtests @ARGV;' integration/*.t.pl


### PR DESCRIPTION
Hello,

I faced the issue on a server where current dir is not in `@INC`, so Perl can't find included test files.
This PR solves the issue.

Thx !

Ben