### PR TITLE
Make Cirle run all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 matrix:
   include:
     - os: linux
-      compiler: gcc
+      compiler: clang #CircleCI tests with gcc
       dist: trusty
     - os: osx
       compiler: clang
@@ -28,8 +28,8 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - attr
-      - clang
       - fuse
       - libfuse-dev
       - gettext
-      - cmake3
+      - clang
+      - clang-tidy-3.9

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if (ENABLE_NLS)
 endif (ENABLE_NLS)
 
 if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.5) # Need 3.6 or above.
-  find_program(CLANG_TIDY_EXE NAMES "clang-tidy" DOC "Path to clang-tidy executable")
+  find_program(CLANG_TIDY_EXE NAMES "clang-tidy" "clang-tidy-3.9" DOC "Path to clang-tidy executable")
   if(NOT CLANG_TIDY_EXE)
     message(STATUS "clang-tidy not found.")
   else()

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,7 +3,12 @@
 cmake --version
 
 CFG=""
-if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+if uname -s | grep -q Linux; then
+  if [ "$TRAVIS" == "true" ]; then
+    CFG="-DLINT=ON"
+  fi
+fi
+if uname -s | grep -q Darwin; then
   CFG="-DENABLE_NLS=OFF -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
 fi
 

--- a/ci/config.sh
+++ b/ci/config.sh
@@ -1,5 +1,0 @@
-set -x
-set -e
-mkdir build
-cd build
-cmake -DCMAKE_INSTALL_PREFIX:PATH=/tmp/encfs -DCMAKE_BUILD_TYPE=Debug ..

--- a/ci/install-gcc.sh
+++ b/ci/install-gcc.sh
@@ -1,5 +1,0 @@
-set -x
-set -e
-sudo apt-get install -y gcc-4.8 g++-4.8
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,10 +1,18 @@
 #!/bin/bash -eu
 
-if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+if uname -s | grep -q Linux; then
   sudo modprobe fuse
+  # Download cmake > 3.5 so that we can run clang-tidy
+  # Circle will use an older one (2.8 in Trusty)
+  if [ "$TRAVIS" == "true" ]; then
+    wget https://cmake.org/files/v3.9/cmake-3.9.1-Linux-x86_64.tar.gz -O /tmp/cmake.tar.gz
+    tar -C /tmp/ -xf /tmp/cmake.tar.gz
+    sudo rm -f $(which cmake)
+    sudo ln -s $(ls -1 /tmp/cmake*/bin/cmake) /bin/
+  fi
 fi
 
-if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+if uname -s | grep -q Darwin; then
   brew cask install osxfuse
 fi
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,11 +4,9 @@ machine:
 
 dependencies:
   pre:
-    - sudo apt-get install cmake libfuse-dev libgettextpo-dev
-    - bash ./ci/install-gcc.sh
+    - sudo apt-get update; sudo apt-get install attr fuse libfuse-dev gettext
 
 test:
   override:
-    - bash ./ci/config.sh
-    - cd build && make && make test && make install
-    - /tmp/encfs/bin/encfsctl --version
+    - ./ci/setup.sh
+    - ./ci/build.sh


### PR DESCRIPTION
Hi,

This PR makes Circle run all tests, as Travis does.
It also makes Travis run clang-tidy.
Travis will use clang, Circle gcc, so that both compilers are tested.

Thx 👍 

Ben