### PR TITLE
Add a new option --reversewrite

### DIFF
--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -1064,14 +1064,6 @@ RootPtr createV6Config(EncFS_Context *ctx,
     if (opts->requireMac) {
       blockMACBytes = 8;
     }
-    if (reverseEncryption) {
-      /* Reverse mounts are read-only by default (set in main.cpp).
-       * If uniqueIV is off, writing can be allowed, because there
-       * is no header that could be overwritten */
-      if (!uniqueIV) {
-        opts->readOnly = false;
-      }
-    }
   }
 
   if (answer[0] == 'x' || alg.name.empty()) {
@@ -1095,11 +1087,11 @@ RootPtr createV6Config(EncFS_Context *ctx,
     if (reverseEncryption) {
       cout << _("reverse encryption - chained IV and MAC disabled") << "\n";
       uniqueIV = selectUniqueIV(false);
-      /* Reverse mounts are read-only by default (set in main.cpp).
-       * If uniqueIV is off, writing can be allowed, because there
-       * is no header that could be overwritten */
-      if (!uniqueIV) {
-        opts->readOnly = false;
+      /* If uniqueIV is off, writing can be allowed, because there
+       * is no header that could be overwritten.
+       * So if it is on, enforce readOnly. */
+      if (uniqueIV) {
+        opts->readOnly = true;
       }
     } else {
       chainedIV = selectChainedIV();
@@ -1581,11 +1573,11 @@ RootPtr initFS(EncFS_Context *ctx, const std::shared_ptr<EncFS_Opts> &opts) {
             "The configuration loaded is not compatible with --reverse\n");
         return rootInfo;
       }
-      /* Reverse mounts are read-only by default (set in main.cpp).
-       * If uniqueIV is off, writing can be allowed, because there
-       * is no header that could be overwritten */
-      if (!config->uniqueIV) {
-        opts->readOnly = false;
+      /* If uniqueIV is off, writing can be allowed, because there
+       * is no header that could be overwritten.
+       * So if it is on, enforce readOnly. */
+      if (config->uniqueIV) {
+        opts->readOnly = true;
       }
     }
 

--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -18,7 +18,7 @@ encfs - mounts or creates an encrypted virtual filesystem
 
 B<encfs> [B<--version>] [B<-v>|B<--verbose>] [B<-t>|B<--syslogtag>] 
 [B<-s>] [B<-f>] [B<--annotate>] [B<--standard>] [B<--paranoia>] 
-[B<--reverse>] [B<--extpass=program>] [B<-S>|B<--stdinpass>] 
+[B<--reverse>] [B<--reversewrite>] [B<--extpass=program>] [B<-S>|B<--stdinpass>] 
 [B<--anykey>] [B<--forcedecode>] [B<-require-macs>] 
 [B<-i MINUTES>|B<--idle=MINUTES>] [B<-m>|B<--ondemand>] [B<--delaymount>] 
 [B<--public>] [B<--nocache>] [B<--no-default-flags>]
@@ -115,7 +115,13 @@ reproduce the unencrypted data:
 Now /tmp/plain-view contains the same data as /home/me
 
 Note that B<--reverse> mode only works with limited configuration options, so
-many settings may be disabled when used.
+many settings may be disabled when used.  Incompatible options as for now : 
+Filename Initialization Vector Chaining and External IV Chaining.
+
+=item B<--reversewrite>
+
+Same as B<--reverse> but will allow writes, if possible (configuration must have
+UniqueIV disabled).  Incompatible option : Per-File Initialization Vectors.
 
 =item B<--extpass=program>
 
@@ -499,6 +505,9 @@ With per-file initialization vectors, each file gets its own 64-bit random
 initialization vector, so that each file is encrypted in a different way.
 
 This option is enabled by default.
+
+Reverse mode derivates IV from inode number, it may then change for example 
+when source files are copied from one FS to another.
 
 =item I<External IV Chaining>
 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -160,6 +160,8 @@ static void usage(const char *name) {
             "\t\t\t(encfs must be run as root)\n")
        << _("  --reverse\t\t"
             "reverse encryption\n")
+       << _("  --reversewrite\t\t"
+            "reverse encryption with writes enabled\n")
 
        // xgroup(usage)
        << _("  --extpass=program\tUse external program for password prompt\n"
@@ -249,6 +251,7 @@ static bool processArgs(int argc, char *argv[],
       {"verbose", 0, nullptr, 'v'},               // verbose mode
       {"version", 0, nullptr, 'V'},               // version
       {"reverse", 0, nullptr, 'r'},               // reverse encryption
+      {"reversewrite", 0, nullptr, 'R'},          // reverse encryption with write enabled
       {"standard", 0, nullptr, '1'},              // standard configuration
       {"paranoia", 0, nullptr, '2'},              // standard configuration
       {"require-macs", 0, nullptr, LONG_OPT_REQUIRE_MAC},  // require MACs
@@ -335,6 +338,12 @@ static bool processArgs(int argc, char *argv[],
          * However, disabling the caches causes a factor 3
          * slowdown. If you are concerned about inconsistencies,
          * please use --nocache. */
+        break;
+      case 'R':
+        out->opts->reverseEncryption = true;
+         /* At least this is what the user wants, we will see later
+            if it is possible */
+        out->opts->readOnly = false;
         break;
       case LONG_OPT_NOCACHE:
         /* Disable EncFS block cache

--- a/integration/reverse.t.pl
+++ b/integration/reverse.t.pl
@@ -3,7 +3,7 @@
 # Test EncFS --reverse mode
 
 use warnings;
-use Test::More tests => 25;
+use Test::More tests => 31;
 use File::Path;
 use File::Temp;
 use IO::Handle;
@@ -212,7 +212,7 @@ symlink_test("foo"); # relative
 symlink_test("/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/15/17/18"); # long
 symlink_test("!§\$%&/()\\<>#+="); # special characters
 symlink_test("$plain/foo");
-# writesDenied(); # disabled as writes are allowed when (uniqueIV == false), we would need a specific reverse conf with (uniqueIV == true).
+writesDenied();
 
 # Umount and delete files
 cleanup();


### PR DESCRIPTION
Hi,

This closes #383, making reverse mode back to read only.
A new option `--reversewrite` allows to clearly mount in reverse with writes allowed.

Thank you 👍 

Ben