### PR TITLE
Integration fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,13 @@ CHECK_CXX_SOURCE_COMPILES("int main() {return 0;}" COMPILER_NEEDS_LATOMIC)
 if(COMPILER_NEEDS_LATOMIC)
         set(ATOMIC_LIBRARY atomic)
 endif()
+# compensate the effect of extra linking of libatomic on platforms where intrinsics are used
+set(CMAKE_REQUIRED_FLAGS "-Wl,--as-needed")
+CHECK_CXX_SOURCE_COMPILES("int main() {return 0;}" LINKER_SUPPORTS_WLASNEEDED)
+if(LINKER_SUPPORTS_WLASNEEDED)
+        list(APPEND EXTRA_LINKER_FLAGS "-Wl,--as-needed")
+endif()
+
 set(CMAKE_REQUIRED_FLAGS)
 
 # Check if we have some standard functions.
@@ -224,6 +231,7 @@ set_target_properties(encfs PROPERTIES
   VERSION ${ENCFS_VERSION}
   SOVERSION ${ENCFS_SOVERSION})
 target_link_libraries(encfs
+  ${EXTRA_LINKER_FLAGS}
   ${FUSE_LIBRARIES}
   ${OPENSSL_LIBRARIES}
   ${TINYXML_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,16 @@ check_cxx_source_compiles ("#include <sys/types.h>
   int main() { getxattr(0,0,0,0,0,0); return 1; }
   " XATTR_ADD_OPT)
 
+# If awailable on current architecture (typically embedded 32-bit), link with it explicitly;
+# GCC autodetection is faulty, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358 and
+# find_libray is no great help here since it is sometimes(!) not in standard paths.
+set(CMAKE_REQUIRED_FLAGS "-latomic")
+CHECK_CXX_SOURCE_COMPILES("int main() {return 0;}" COMPILER_NEEDS_LATOMIC)
+if(COMPILER_NEEDS_LATOMIC)
+        set(ATOMIC_LIBRARY atomic)
+endif()
+set(CMAKE_REQUIRED_FLAGS)
+
 # Check if we have some standard functions.
 include (CheckFuncs)
 check_function_exists_glibc (lchmod HAVE_LCHMOD)
@@ -220,6 +230,7 @@ target_link_libraries(encfs
   ${EASYLOGGING_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT}
   ${Intl_LIBRARIES}
+  ${ATOMIC_LIBRARY}
 )
 if (INSTALL_LIBENCFS)
   install (TARGETS encfs DESTINATION ${LIB_INSTALL_DIR})


### PR DESCRIPTION
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872565 and
buildd.debian.org build logs.

The code fails to build on some architectures. A simple check with find_library is not enough, I tried it already in my apt-cacher-ng package and works on some (like mips) but fails on others (like powerpc). This workaround seems to fix powerpc build (only tested in v1.9.2 on powerpc 32bit but this should be a representative test for all such issues, IMHO).