### PR TITLE
Document cloud usage in man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ How about a nice email instead?
 
 ### What settings should I use for Dropbox?
 
-Use **standard mode**. There have been [reports](https://github.com/vgough/encfs/issues/388)
+Use **standard mode**. There [have](https://github.com/vgough/encfs/issues/141)
+been [reports](https://github.com/vgough/encfs/issues/388)
 of a pathological interaction of paranoia mode with Dropbox' rename
 detection. The problem seems to be with `External IV chaining`, which is
 not active in standard mode.

--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -525,6 +525,11 @@ be allowed when the user has write access to the file.
 Because of these limits, this option is disabled by default for standard mode
 (and enabled by default for paranoia mode).
 
+This option may be incompatible with some cloud providers, as during a rename,
+file's content changes, but not its timestamp. Due to this, file's changes may
+no be correctly seen by cloud providers' sync programs. It is then not
+recommended for cloud usage.
+
 =item I<Block MAC headers>
 
 B<New to 1.1>.  If this is enabled, every block in every file is stored along


### PR DESCRIPTION
Hi,

Here are some comments in man page to discourage using external IV chaining with cloud providers.
We should then be able to somehow close #141.

Thx 👍 

Ben