### PR TITLE
Add an (empty) encfssh man page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,7 +313,11 @@ if (POD2MAN)
     COMMAND ${POD2MAN} -u --section=1 --release=${ENCFS_VERSION} --center=${ENCFS_NAME}
             ${CMAKE_CURRENT_LIST_DIR}/encfs/encfsctl.pod encfsctl.1)
 
-  install (FILES ${CMAKE_BINARY_DIR}/encfs.1 ${CMAKE_BINARY_DIR}/encfsctl.1
+  add_custom_target (encfssh-man ALL
+    COMMAND ${POD2MAN} -u --section=1 --release=${ENCFS_VERSION} --center=${ENCFS_NAME}
+            ${CMAKE_CURRENT_LIST_DIR}/encfs/encfssh.pod encfssh.1)
+
+  install (FILES ${CMAKE_BINARY_DIR}/encfs.1 ${CMAKE_BINARY_DIR}/encfsctl.1 ${CMAKE_BINARY_DIR}/encfssh.1
     DESTINATION ${MAN_DESTINATION})
 endif (POD2MAN)
 

--- a/encfs/encfssh.pod
+++ b/encfs/encfssh.pod
@@ -1,0 +1,33 @@
+=pod
+
+=cut
+
+Copyright (c) 2003-2008, Valient Gough <vgough@pobox.com>
+All rights reserved.
+
+EncFS is free software; you can distribute it and/or modify it under the terms
+of the GNU General Public License (GPL), as published by the Free Software
+Foundation; either version 3 of the License, or (at your option) any later
+version.
+
+=head1 NAME
+
+encfssh - mount encrypted virtual filesystem and start shell
+
+Write in progress...
+
+=head1 DISCLAIMER
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  Please refer to the "COPYING" file distributed with
+B<EncFS> for complete details.
+
+=head1 AUTHORS
+
+B<EncFS> was written by B<< Valient Gough <vgough@pobox.com> >>.
+
+=head1 SEE ALSO
+
+encfs(1)
+


### PR DESCRIPTION
Hi,

This adds an (almost empty) `encfssh` man page, to avoid warnings building packages (see #351).

Of course this man page would have to be fully written.

Ben