### PR TITLE
Ensure compatibility with LibreSSL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,7 +52,7 @@ Dependencies
 EncFS depends on a number of libraries:
 
     * fuse : the userspace filesystem layer
-    * openssl : used for cryptographic primitives
+    * openssl or libressl : used for cryptographic primitives
     * tinyxml2 : for reading and writing XML configuration files
     * gettext : internationalization support
     * libintl : internationalization support

--- a/encfs/SSL_Compat.h
+++ b/encfs/SSL_Compat.h
@@ -22,7 +22,7 @@
 #define _SSL_Compat_incl_
 
 // OpenSSL < 1.1.0
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 // Equivalent methods
 #define EVP_MD_CTX_new EVP_MD_CTX_create

--- a/encfs/SSL_Compat.h
+++ b/encfs/SSL_Compat.h
@@ -21,7 +21,7 @@
 #ifndef _SSL_Compat_incl_
 #define _SSL_Compat_incl_
 
-// OpenSSL < 1.1.0
+// OpenSSL < 1.1.0 or LibreSSL
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 // Equivalent methods


### PR DESCRIPTION
This fixes compilation with [LibreSSL](https://www.libressl.org/). Tested with **2.2.9+**.