### PR TITLE
Correctly set gid/uid when allow_other is used

### DIFF
--- a/encfs/DirNode.cpp
+++ b/encfs/DirNode.cpp
@@ -501,11 +501,21 @@ int DirNode::mkdir(const char *plaintextPath, mode_t mode, uid_t uid,
   // if uid or gid are set, then that should be the directory owner
   int olduid = -1;
   int oldgid = -1;
-  if (uid != 0) {
-    olduid = setfsuid(uid);
-  }
   if (gid != 0) {
     oldgid = setfsgid(gid);
+    if (oldgid == -1) {
+      int eno = errno;
+      RLOG(DEBUG) << "setfsgid error: " << strerror(eno);
+      return -EPERM;
+    }
+  }
+  if (uid != 0) {
+    olduid = setfsuid(uid);
+    if (olduid == -1) {
+      int eno = errno;
+      RLOG(DEBUG) << "setfsuid error: " << strerror(eno);
+      return -EPERM;
+    }
   }
 
   int res = ::mkdir(cyName.c_str(), mode);

--- a/encfs/FileNode.cpp
+++ b/encfs/FileNode.cpp
@@ -154,19 +154,19 @@ int FileNode::mknod(mode_t mode, dev_t rdev, uid_t uid, gid_t gid) {
   int res;
   int olduid = -1;
   int oldgid = -1;
-  if (uid != 0) {
-    olduid = setfsuid(uid);
-    if (olduid == -1) {
-      int eno = errno;
-      RLOG(DEBUG) << "setfsuid error: " << strerror(eno);
-      return -EPERM;
-    }
-  }
   if (gid != 0) {
     oldgid = setfsgid(gid);
     if (oldgid == -1) {
       int eno = errno;
       RLOG(DEBUG) << "setfsgid error: " << strerror(eno);
+      return -EPERM;
+    }
+  }
+  if (uid != 0) {
+    olduid = setfsuid(uid);
+    if (olduid == -1) {
+      int eno = errno;
+      RLOG(DEBUG) << "setfsuid error: " << strerror(eno);
       return -EPERM;
     }
   }

--- a/encfs/encfs.h
+++ b/encfs/encfs.h
@@ -41,8 +41,7 @@ static __inline int setfsuid(uid_t uid) {
   uid_t olduid = geteuid();
 
   if (seteuid(uid) != 0) {
-    int eno = errno;
-    VLOG(1) << "seteuid error: " << strerror(eno);
+    return -1;
   }
 
   return olduid;
@@ -52,8 +51,7 @@ static __inline int setfsgid(gid_t gid) {
   gid_t oldgid = getegid();
 
   if (setegid(gid) != 0) {
-    int eno = errno;
-    VLOG(1) << "setfsgid error: " << strerror(eno);
+    return -1;
   }
 
   return oldgid;


### PR DESCRIPTION
Hi,

This change fixes the `setfsgid` bug found in #398 and should then fix this issue.

Fix was to run `setfsgid` before `setfsuid`, as of course the reverse order can't work.

Ben