### PR TITLE
Replace "linux" define with more-standard "__linux__"

### DIFF
--- a/encfs/DirNode.cpp
+++ b/encfs/DirNode.cpp
@@ -31,7 +31,7 @@
 #include "FileNode.h"
 #include "FileUtils.h"
 #include "NameIO.h"
-#ifdef linux
+#ifdef __linux__
 #include <sys/fsuid.h>
 #endif
 

--- a/encfs/FileNode.cpp
+++ b/encfs/FileNode.cpp
@@ -24,7 +24,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#ifdef linux
+#ifdef __linux__
 #include <sys/fsuid.h>
 #endif
 

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -19,7 +19,7 @@
  */
 
 // defines needed for RedHat 7.3...
-#ifdef linux
+#ifdef __linux__
 #define _XOPEN_SOURCE 500  // make sure pwrite() is pulled in
 #endif
 #define _BSD_SOURCE      // pick up setenv on RH7.3

--- a/encfs/RawFileIO.cpp
+++ b/encfs/RawFileIO.cpp
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef linux
+#ifdef __linux__
 #define _XOPEN_SOURCE 500  // pick up pread , pwrite
 #endif
 #include "easylogging++.h"

--- a/encfs/encfs.cpp
+++ b/encfs/encfs.cpp
@@ -32,7 +32,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <utime.h>
-#ifdef linux
+#ifdef __linux__
 #include <sys/fsuid.h>
 #endif
 

--- a/encfs/encfs.h
+++ b/encfs/encfs.h
@@ -34,7 +34,7 @@ namespace encfs {
 #define HAVE_XATTR
 #endif
 
-#ifndef linux
+#ifndef __linux__
 #include <cerrno>
 
 static __inline int setfsuid(uid_t uid) {


### PR DESCRIPTION
The "linux" define is not available with "g++ -std=c++11",
which resulted in bug https://github.com/vgough/encfs/issues/398 .

Available defines for gcc 7.1.1, g++ 7.1.7, clang 4.0.0:

$ g++ -dM -E -x c++ /dev/null | grep linux

$ g++ -dM -E -x c++ -std=c++11 /dev/null | grep linux

$ echo "" | gcc -E -dM -c - | grep linux

$ echo "" | clang -E - -dM | grep linux