### PR TITLE
Correct an uninitialized value

### DIFF
--- a/encfs/ConfigVar.cpp
+++ b/encfs/ConfigVar.cpp
@@ -186,7 +186,7 @@ const ConfigVar &operator>>(const ConfigVar &src, std::string &result) {
 
   int readLen;
 
-  unsigned char tmpBuf[32];
+  unsigned char tmpBuf[32] = {};
   if (length > (int)sizeof(tmpBuf)) {
     auto *ptr = new unsigned char[length];
     readLen = src.read(ptr, length);


### PR DESCRIPTION
Hi,

Trying to correct this from clang :
```/home/travis/build/vgough/encfs/encfs/ConfigVar.cpp:197:5: warning: Function call argument is a pointer to uninitialized value```

Ben