### PR TITLE
Correct last compilation warnings in readpassphrase

### DIFF
--- a/encfs/readpassphrase.cpp
+++ b/encfs/readpassphrase.cpp
@@ -126,29 +126,30 @@ restart:
   }
 
   if (write(output, prompt, strlen(prompt)) != -1) {
-    end = buf + bufsiz - 1;
-    for (p = buf; (nr = read(input, &ch, 1)) == 1 && ch != '\n' && ch != '\r';) {
-      if (p < end) {
-        if ((flags & RPP_SEVENBIT) != 0) {
-          ch &= 0x7f;
-        }
-        if (isalpha(ch) != 0) {
-          if ((flags & RPP_FORCELOWER) != 0) {
-            ch = tolower(ch);
-          }
-          if ((flags & RPP_FORCEUPPER) != 0) {
-            ch = toupper(ch);
-          }
-        }
-        *p++ = ch;
-      }
-    }
-    *p = '\0';
+    //dummy test to get rid of warn_unused_result compilation warning
   }
+  end = buf + bufsiz - 1;
+  for (p = buf; (nr = read(input, &ch, 1)) == 1 && ch != '\n' && ch != '\r';) {
+    if (p < end) {
+      if ((flags & RPP_SEVENBIT) != 0) {
+        ch &= 0x7f;
+      }
+      if (isalpha(ch) != 0) {
+        if ((flags & RPP_FORCELOWER) != 0) {
+          ch = tolower(ch);
+        }
+        if ((flags & RPP_FORCEUPPER) != 0) {
+          ch = toupper(ch);
+        }
+      }
+      *p++ = ch;
+    }
+  }
+  *p = '\0';
   save_errno = errno;
   if ((term.c_lflag & ECHO) == 0u) {
-    if(write(output, "\n", 1) != -1) {
-    	//dummy test to get rid of warn_unused_result compilation warning
+    if (write(output, "\n", 1) != -1) {
+      //dummy test to get rid of warn_unused_result compilation warning
     }
   }
 


### PR DESCRIPTION
Hi,

This PR corrects last compilation warnings regarding `readpassphrase.cpp`.
It comes back to the original file, simply adding a dummy test to avoid the `(void)write()` warnings.
Will then help to progress on #426.

```
/home/makerpm/rpmbuild/BUILD/encfs-master/encfs/readpassphrase.cpp:128:46: warning: ignoring return value of 'ssize_t write(int, const void*, size_t)', declared with attribute warn_unused_result [-Wunused-result]
   (void)write(output, prompt, strlen(prompt));
                                              ^
/home/makerpm/rpmbuild/BUILD/encfs-master/encfs/readpassphrase.cpp:149:33: warning: ignoring return value of 'ssize_t write(int, const void*, size_t)', declared with attribute warn_unused_result [-Wunused-result]
     (void)write(output, "\n", 1);
                                 ^
```

Thank you !