### PR TITLE
Correct macro-parentheses clang warning

### DIFF
--- a/encfs/MemoryPool.cpp
+++ b/encfs/MemoryPool.cpp
@@ -33,7 +33,7 @@
 
 #include <openssl/buffer.h>
 
-#define BLOCKDATA(BLOCK) (unsigned char *)BLOCK->data->data
+#define BLOCKDATA(BLOCK) (unsigned char *)(BLOCK)->data->data
 
 namespace encfs {
 

--- a/encfs/readpassphrase.cpp
+++ b/encfs/readpassphrase.cpp
@@ -116,8 +116,9 @@ restart:
       term.c_lflag &= ~(ECHO | ECHONL);
     }
 #ifdef VSTATUS
-    if (term.c_cc[VSTATUS] != _POSIX_VDISABLE)
+    if (term.c_cc[VSTATUS] != _POSIX_VDISABLE) {
       term.c_cc[VSTATUS] = _POSIX_VDISABLE;
+    }
 #endif
     (void)tcsetattr(input, _T_FLUSH, &term);
   } else {


### PR DESCRIPTION
Hi,

This PR helps with #427, it solves clang warnings regarding macro-parentheses.

Thank you 👍 

Ben