### PR TITLE
Correct explicit-constructor clang warning

### DIFF
--- a/encfs/XmlReader.cpp
+++ b/encfs/XmlReader.cpp
@@ -154,7 +154,7 @@ class XmlNode : virtual public XmlValue {
   const tinyxml2::XMLElement *element;
 
  public:
-  XmlNode(const tinyxml2::XMLElement *element_)
+  explicit XmlNode(const tinyxml2::XMLElement *element_)
       : XmlValue(safeValueForNode(element_)), element(element_) {}
 
   ~XmlNode() override = default;

--- a/encfs/autosprintf.h
+++ b/encfs/autosprintf.h
@@ -48,8 +48,8 @@ class autosprintf {
   /* Destructor: frees the temporarily allocated string.  */
   ~autosprintf();
   /* Conversion to string.  */
-  operator char*() const;
-  operator std::string() const;
+  explicit operator char*() const;
+  explicit operator std::string() const;
   /* Output to an ostream.  */
   friend inline std::ostream& operator<<(std::ostream& stream,
                                          const autosprintf& tmp) {


### PR DESCRIPTION
Hi,

This PR helps with #427, it solves clang warnings regarding explicit-constructor.

Thank you 👍 

Ben