### PR TITLE
Correct unnecessary-value-param clang warnings

### DIFF
--- a/encfs/base64.cpp
+++ b/encfs/base64.cpp
@@ -252,7 +252,7 @@ bool B64StandardDecode(unsigned char *out, const unsigned char *in, int inLen) {
 // If you want to use an alternate alphabet, change the characters here
 const static char encodeLookup[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-std::string B64StandardEncode(std::vector<unsigned char> &inputBuffer) {
+std::string B64StandardEncode(const std::vector<unsigned char> &inputBuffer) {
   std::string encodedString;
   encodedString.reserve(B256ToB64Bytes(inputBuffer.size()));
   long temp;

--- a/encfs/base64.cpp
+++ b/encfs/base64.cpp
@@ -252,7 +252,7 @@ bool B64StandardDecode(unsigned char *out, const unsigned char *in, int inLen) {
 // If you want to use an alternate alphabet, change the characters here
 const static char encodeLookup[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-std::string B64StandardEncode(std::vector<unsigned char> inputBuffer) {
+std::string B64StandardEncode(std::vector<unsigned char> &inputBuffer) {
   std::string encodedString;
   encodedString.reserve(B256ToB64Bytes(inputBuffer.size()));
   long temp;

--- a/encfs/base64.h
+++ b/encfs/base64.h
@@ -73,7 +73,7 @@ void AsciiToB32(unsigned char *out, const unsigned char *in, int length);
 bool B64StandardDecode(unsigned char *out, const unsigned char *in,
                        int inputLen);
 
-std::string B64StandardEncode(std::vector<unsigned char> input);
+std::string B64StandardEncode(std::vector<unsigned char> &input);
 
 }  // namespace encfs
 

--- a/encfs/base64.h
+++ b/encfs/base64.h
@@ -73,7 +73,7 @@ void AsciiToB32(unsigned char *out, const unsigned char *in, int length);
 bool B64StandardDecode(unsigned char *out, const unsigned char *in,
                        int inputLen);
 
-std::string B64StandardEncode(std::vector<unsigned char> &input);
+std::string B64StandardEncode(const std::vector<unsigned char> &input);
 
 }  // namespace encfs
 

--- a/encfs/encfs.cpp
+++ b/encfs/encfs.cpp
@@ -135,7 +135,7 @@ static void checkCanary(const std::shared_ptr<FileNode> &fnode) {
 // helper function -- apply a functor to a node
 static int withFileNode(const char *opName, const char *path,
                         struct fuse_file_info *fi,
-                        function<int(FileNode *)> op) {
+                        const function<int(FileNode *)> &op) {
   EncFS_Context *ctx = context();
 
   int res = -EIO;


### PR DESCRIPTION
Hi,

This PR helps with #427, it solves clang warnings regarding unnecessary-value-param.
**Please review with care.**

Thx 👍 

Ben