### PR TITLE
Make Travis to use correct clang-tidy version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ if (ENABLE_NLS)
 endif (ENABLE_NLS)
 
 if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.5) # Need 3.6 or above.
-  find_program(CLANG_TIDY_EXE NAMES "clang-tidy" "clang-tidy-4.0" DOC "Path to clang-tidy executable")
+  find_program(CLANG_TIDY_EXE NAMES "clang-tidy-4.0" "clang-tidy40" "clang-tidy" DOC "Path to clang-tidy executable")
   if(NOT CLANG_TIDY_EXE)
     message(STATUS "clang-tidy not found.")
   else()


### PR DESCRIPTION
Hi,

This PR makes Travis to use correct expected clang-tidy version, so version 4.0, instead of default found 3.9.
The PR also declares FreeBSD clang-tidy binary name which slightly differs.

Thank you 👍 

Ben