### PR TITLE
Add a lock condition before idle unmount

### DIFF
--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -188,7 +188,10 @@ Enable automatic unmount of the filesystem after a period of inactivity.  The
 period is specified in minutes, so the shortest timeout period that can be
 requested is one minute.  B<EncFS> will not automatically unmount if there are
 files open within the filesystem, even if they are open in read-only mode.
-However simply having files open does not count as activity.
+However simply having files open does not count as activity.  EncFS will try
+to lock mount point just before unmounting, and will unmount only if lock
+succeeds, giving users the ability to handle races when EncFS is used in
+automated tools or scripts.
 
 =item B<-m>, B<--ondemand>
 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -784,8 +784,8 @@ static void *idleMonitor(void *_arg) {
         RLOG(WARNING) << "Filesystem inactive, but " << openCount
                       << " files opened: " << arg->opts->mountPoint;
       } else {
-      	/* try to lock the mount point to give an oportunity to handle races
-      	   with an automated tool or script using --idle. */
+        /* try to lock the mount point to give an oportunity to handle races
+           with an automated tool or script using --idle. */
         int fdlock = open(arg->opts->mountPoint.c_str(),O_RDONLY);
         if (flock(fdlock, LOCK_EX|LOCK_NB) == -1) {
           RLOG(WARNING) << "Filesystem inactive, but "

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -22,13 +22,13 @@
 #include <cstring>
 #include <ctime>
 #include <exception>
-#include <sys/file.h>
 #include <getopt.h>
 #include <iostream>
 #include <memory>
 #include <pthread.h>
 #include <sstream>
 #include <string>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <unistd.h>


### PR DESCRIPTION
Hi,

As documented into the updated man page, this PR adds a lock condition when using `--idle` :
_EncFS will try to lock mount point just before unmounting, and will unmount only if lock succeeds, giving users the ability to handle races when EncFS is used in automated tools or scripts._

This allows for example an automated tool to lock the mount point before checking if it is already mounted, and mount it if needed, avoiding races with `--idle` if mount point is already mounted.

Thank you very much 👍 

Ben
