### PR TITLE
Correct unused-parameter warnings

### DIFF
--- a/encfs/DirNode.cpp
+++ b/encfs/DirNode.cpp
@@ -55,8 +55,6 @@ DirTraverse::DirTraverse(std::shared_ptr<DIR> _dirPtr, uint64_t _iv,
                          std::shared_ptr<NameIO> _naming)
     : dir(std::move(_dirPtr)), iv(_iv), naming(std::move(_naming)) {}
 
-DirTraverse::DirTraverse(const DirTraverse &src) = default;
-
 DirTraverse &DirTraverse::operator=(const DirTraverse &src) = default;
 
 DirTraverse::~DirTraverse() {

--- a/encfs/DirNode.h
+++ b/encfs/DirNode.h
@@ -50,7 +50,6 @@ class DirTraverse {
  public:
   DirTraverse(std::shared_ptr<DIR> dirPtr, uint64_t iv,
               std::shared_ptr<NameIO> naming);
-  DirTraverse(const DirTraverse &src);
   ~DirTraverse();
 
   DirTraverse &operator=(const DirTraverse &src);

--- a/encfs/Interface.cpp
+++ b/encfs/Interface.cpp
@@ -36,10 +36,6 @@ Interface::Interface(std::string name_, int Current, int Revision, int Age)
       _revision(Revision),
       _age(Age) {}
 
-Interface::Interface(const Interface &src)
-
-    = default;
-
 Interface::Interface() : _current(0), _revision(0), _age(0) {}
 
 Interface &Interface::operator=(const Interface &src) = default;

--- a/encfs/Interface.h
+++ b/encfs/Interface.h
@@ -38,7 +38,6 @@ class Interface {
   */
   Interface(const char *name, int Current, int Revision, int Age);
   Interface(std::string name, int Current, int Revision, int Age);
-  Interface(const Interface &src);
   Interface();
 
   // check if we implement the interface described by B.


### PR DESCRIPTION
Hi,

This helps solving #426.

It solves following warnings :
```
In file included from DirNode.cpp:21:0:
DirNode.h:49:7: warning: unused parameter ‘src’ [-Wunused-parameter]
 class DirTraverse {
       ^
DirNode.cpp:58:52: note: synthesized method ‘encfs::DirTraverse::DirTraverse(const encfs::DirTraverse&)’ first required here 
 DirTraverse::DirTraverse(const DirTraverse &src) = default;
                                                    ^

In file included from Interface.cpp:21:0:
Interface.h:30:7: warning: unused parameter ‘src’ [-Wunused-parameter]
 class Interface {
       ^
Interface.cpp:41:7: note: synthesized method ‘encfs::Interface::Interface(const encfs::Interface&)’ first required here 
     = default;
       ^
```

Thx 👍 

Ben