### PR TITLE
Correct readability-non-const-parameter warning

### DIFF
--- a/encfs/SSL_Cipher.cpp
+++ b/encfs/SSL_Cipher.cpp
@@ -505,7 +505,7 @@ CipherKey SSL_Cipher::newRandomKey() {
     compute a 64-bit check value for the data using HMAC.
 */
 static uint64_t _checksum_64(SSLKey *key, const unsigned char *data,
-                             int dataLen, const uint64_t *chainedIV) {
+                             int dataLen, const uint64_t *const chainedIV) {
   rAssert(dataLen > 0);
   Lock lock(key->mutex);
 

--- a/encfs/SSL_Cipher.cpp
+++ b/encfs/SSL_Cipher.cpp
@@ -505,7 +505,7 @@ CipherKey SSL_Cipher::newRandomKey() {
     compute a 64-bit check value for the data using HMAC.
 */
 static uint64_t _checksum_64(SSLKey *key, const unsigned char *data,
-                             int dataLen, uint64_t *const chainedIV) {
+                             int dataLen, const uint64_t *chainedIV) {
   rAssert(dataLen > 0);
   Lock lock(key->mutex);
 


### PR DESCRIPTION
Hi,

This helps solving #427, correcting the following :
```
SSL_Cipher.cpp:508:59: warning: pointer parameter 'chainedIV' can be pointer to const [readability-non-const-parameter]
                             int dataLen, uint64_t *const chainedIV) {
                                                          ^
                                          const 
```

Ben