### PR TITLE
Correct performance warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.5) # Need 3.6 or abo
       ",-google-runtime-int"
       ",-google-runtime-references"
       ",-modernize-loop-convert"
+      ",-performance-inefficient-string-concatenation"
       ",-readability-inconsistent-declaration-parameter-name"
       ",-readability-named-parameter"
       )

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -465,7 +465,7 @@ bool saveConfig(ConfigType type, const string &rootDir,
 template <typename T>
 tinyxml2::XMLElement *addEl(tinyxml2::XMLDocument &doc,
                             tinyxml2::XMLNode *parent, const char *name,
-                            T value) {
+                            const T &value) {
   auto el = doc.NewElement(name);
   el->SetText(value);
   parent->InsertEndChild(el);
@@ -475,7 +475,7 @@ tinyxml2::XMLElement *addEl(tinyxml2::XMLDocument &doc,
 template <>
 tinyxml2::XMLElement *addEl<>(tinyxml2::XMLDocument &doc,
                               tinyxml2::XMLNode *parent, const char *name,
-                              Interface iface) {
+                              const Interface &iface) {
   auto el = doc.NewElement(name);
 
   auto n = doc.NewElement("name");
@@ -497,7 +497,7 @@ tinyxml2::XMLElement *addEl<>(tinyxml2::XMLDocument &doc,
 template <>
 tinyxml2::XMLElement *addEl<>(tinyxml2::XMLDocument &doc,
                               tinyxml2::XMLNode *parent, const char *name,
-                              std::vector<unsigned char> data) {
+                              const std::vector<unsigned char> &data) {
   string v = string("\n") + B64StandardEncode(data) + "\n";
   return addEl(doc, parent, name, v.c_str());
 }


### PR DESCRIPTION
Hi,

This PR helps solving #427, correcting :

```
DirNode.cpp:423:41: warning: string concatenation results in allocation of unnecessary temporary strings; consider using 'operator+=' or 'string::append()' instead [performance-inefficient-string-concatenation]
      string newFull = sourcePath + '/' + newName;
                                        ^
```
_here it disables the Clang test_

However, I'm not sure how to handle this one :
```
FileUtils.cpp:500:58: warning: the parameter 'data' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
                              std::vector<unsigned char> data) {
                                                         ^
```

Edit : just found a way, please **review with care** !

Thx 👍 

Ben