### PR TITLE
Disable Clang C-style variadic warnings in autosprintf

### DIFF
--- a/encfs/autosprintf.cpp
+++ b/encfs/autosprintf.cpp
@@ -35,7 +35,7 @@
 namespace gnu {
 
 /* Constructor: takes a format string and the printf arguments.  */
-autosprintf::autosprintf(const char *format, ...) {
+autosprintf::autosprintf(const char *format, ...) { // NOLINT (cert-dcl50-cpp) as it's not critical
   va_list args;
   va_start(args, format);
   if (vasprintf(&str, format, args) < 0) {
@@ -50,7 +50,9 @@ autosprintf::autosprintf(const autosprintf &src) {
 }
 
 /* Destructor: frees the temporarily allocated string.  */
-autosprintf::~autosprintf() { free(str); }
+autosprintf::~autosprintf() {
+  free(str); // NOLINT (cppcoreguidelines-no-malloc) as it's a consequence of vasprintf / variadic function above
+}
 
 /* Conversion to string.  */
 autosprintf::operator char *() const {


### PR DESCRIPTION
Hi,

This PR helps with #427 disabling Clang C-style variadic warnings in autosprintf.

Thx 👍 

For reference, the following disabled warning :
```
autosprintf.cpp:38:14: warning: do not define a C-style variadic function; consider using a function parameter pack or currying instead [cert-dcl50-cpp]
autosprintf::autosprintf(const char *format, ...) {
 ^
```
leads to :
https://www.securecoding.cert.org/confluence/display/cplusplus/DCL50-CPP.+Do+not+define+a+C-style+variadic+function

and to several implementations :
https://gist.github.com/sehe/3374327
https://github.com/tromey/typesafe-printf
https://github.com/fmtlib/fmt
