### PR TITLE
Correct FSF address.

### DIFF
--- a/encfs/autosprintf.cpp
+++ b/encfs/autosprintf.cpp
@@ -14,8 +14,8 @@
 
    You should have received a copy of the GNU Library General Public
    License along with this program; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
-   USA.  */
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+   USA. */
 
 /* Tell glibc's <stdio.h> to provide a prototype for vasprintf().
    This must come before <config.h> because <config.h> may include

--- a/encfs/autosprintf.cpp
+++ b/encfs/autosprintf.cpp
@@ -2,20 +2,18 @@
    Copyright (C) 2002 Free Software Foundation, Inc.
    Written by Bruno Haible <bruno@clisp.org>, 2002.
 
-   This program is free software; you can redistribute it and/or modify it
-   under the terms of the GNU Library General Public License as published
-   by the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Library General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Library General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Library General Public License for more details.
 
-   You should have received a copy of the GNU Library General Public
-   License along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
-   USA. */
+   You should have received a copy of the GNU Library General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 /* Tell glibc's <stdio.h> to provide a prototype for vasprintf().
    This must come before <config.h> because <config.h> may include

--- a/encfs/autosprintf.h
+++ b/encfs/autosprintf.h
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Library General Public
    License along with this program; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
-   USA.  */
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+   USA. */
 
 #ifndef _AUTOSPRINTF_H
 #define _AUTOSPRINTF_H

--- a/encfs/autosprintf.h
+++ b/encfs/autosprintf.h
@@ -1,20 +1,18 @@
 /* Class autosprintf - formatted output to an ostream.
    Copyright (C) 2002 Free Software Foundation, Inc.
 
-   This program is free software; you can redistribute it and/or modify it
-   under the terms of the GNU Library General Public License as published
-   by the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Library General Public License as published by
+   the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Library General Public License for more details.
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Library General Public License for more details.
 
-   You should have received a copy of the GNU Library General Public
-   License along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
-   USA. */
+   You should have received a copy of the GNU Library General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 #ifndef _AUTOSPRINTF_H
 #define _AUTOSPRINTF_H


### PR DESCRIPTION
Corrected FSF address in source files corresponding to https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt