### PR TITLE
Correct a int/off_t buffer overflow in getSize()

### DIFF
--- a/encfs/FileNode.cpp
+++ b/encfs/FileNode.cpp
@@ -228,7 +228,7 @@ int FileNode::getAttr(struct stat *stbuf) const {
 off_t FileNode::getSize() const {
   Lock _lock(mutex);
 
-  int res = io->getSize();
+  off_t res = io->getSize();
   return res;
 }
 


### PR DESCRIPTION
Hi,

This closes #467.

Thx 👍 

Ben