### PR TITLE
Do not count usage on root path

### DIFF
--- a/encfs/Context.cpp
+++ b/encfs/Context.cpp
@@ -47,7 +47,12 @@ EncFS_Context::~EncFS_Context() {
   // release all entries from map
   openFiles.clear();
 }
+
 std::shared_ptr<DirNode> EncFS_Context::getRoot(int *errCode) {
+  return getRoot(errCode, false);
+}
+
+std::shared_ptr<DirNode> EncFS_Context::getRoot(int *errCode, bool skipUsageCount) {
   std::shared_ptr<DirNode> ret = nullptr;
   do {
     {
@@ -57,7 +62,11 @@ std::shared_ptr<DirNode> EncFS_Context::getRoot(int *errCode) {
         break;      	
       }
       ret = root;
-      ++usageCount;
+      // On some system, stat of "/" is allowed even if the calling user is
+      // not allowed to list / to go deeper. Do not then count this call.
+      if (!skipUsageCount) {
+        ++usageCount;
+      }
     }
 
     if (!ret) {

--- a/encfs/Context.h
+++ b/encfs/Context.h
@@ -56,6 +56,7 @@ class EncFS_Context {
 
   void setRoot(const std::shared_ptr<DirNode> &root);
   std::shared_ptr<DirNode> getRoot(int *err);
+  std::shared_ptr<DirNode> getRoot(int *err, bool skipUsageCount);
 
   std::shared_ptr<EncFS_Args> args;
   std::shared_ptr<EncFS_Opts> opts;

--- a/encfs/encfs.cpp
+++ b/encfs/encfs.cpp
@@ -139,7 +139,11 @@ static int withFileNode(const char *opName, const char *path,
   EncFS_Context *ctx = context();
 
   int res = -EIO;
-  std::shared_ptr<DirNode> FSRoot = ctx->getRoot(&res);
+  bool skipUsageCount = false;
+  if (strlen(path) == 1) {
+    skipUsageCount = true;
+  }
+  std::shared_ptr<DirNode> FSRoot = ctx->getRoot(&res, skipUsageCount);
   if (!FSRoot) {
     return res;
   }


### PR DESCRIPTION
Hi,

On some systems, at least on FreeBSD, an user which is not allowed to access an EncFS folder can at least stat its mountpoint.
This user can then prevent the `--idle` option to work regularly stating the mountpoint.

This PR corrects this issue dropping usage counts made on root path `/`.

Thank you 👍 

Ben
