### PR TITLE
Add -c & -u cmdline options

### DIFF
--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -35,6 +35,10 @@
 #include <fstream>
 #include <iostream>
 #include <list>
+#ifdef __APPLE__
+#include <sys/mount.h>
+#include <sys/param.h>
+#endif
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
@@ -1703,10 +1707,10 @@ bool unmountFS(EncFS_Context *ctx) {
     return false;
   }
 // Time to unmount!
-#if FUSE_USE_VERSION < 30
   fuse_unmount(ctx->opts->mountPoint.c_str(), nullptr);
-#else
-  fuse_unmount(fuse_get_context()->fuse);
+#ifdef __APPLE__
+  // fuse_unmount does not work on Mac OS, see #428
+  unmount(ctx->opts->mountPoint.c_str(), MNT_FORCE);
 #endif
   // fuse_unmount succeeds and returns void
   RLOG(INFO) << "Filesystem inactive, unmounted: " << ctx->opts->mountPoint;

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -136,6 +136,8 @@ class EncFS_Context;
 
 RootPtr initFS(EncFS_Context *ctx, const std::shared_ptr<EncFS_Opts> &opts);
 
+void unmountFS(const char *mountPoint);
+
 RootPtr createV6Config(EncFS_Context *ctx,
                        const std::shared_ptr<EncFS_Opts> &opts);
 

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -76,6 +76,7 @@ struct EncFS_Opts {
   bool idleTracking;       // turn on idle monitoring of filesystem
   bool mountOnDemand;      // mounting on-demand
   bool delayMount;         // delay initial mount
+  bool unmount;            // unmount
 
   bool checkKey;     // check crypto key decoding
   bool forceDecode;  // force decode on MAC block failures
@@ -105,6 +106,7 @@ struct EncFS_Opts {
     idleTracking = false;
     mountOnDemand = false;
     delayMount = false;
+    unmount = false;
     checkKey = true;
     forceDecode = false;
     useStdin = false;

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -98,6 +98,7 @@ struct EncFS_Opts {
   bool requireMac;  // Throw an error if MAC is disabled
 
   ConfigMode configMode;
+  std::string config;  // path to configuration file (or empty)
 
   EncFS_Opts() {
     createIfNotFound = true;
@@ -120,14 +121,14 @@ struct EncFS_Opts {
 /*
     Read existing config file.  Looks for any supported configuration version.
 */
-ConfigType readConfig(const std::string &rootDir, EncFSConfig *config);
+ConfigType readConfig(const std::string &rootDir, EncFSConfig *config, const std::string &cmdConfig);
 
 /*
     Save the configuration.  Saves back as the same configuration type as was
     read from.
 */
 bool saveConfig(ConfigType type, const std::string &rootdir,
-                const EncFSConfig *config);
+                const EncFSConfig *config, const std::string &cmdConfig);
 
 class EncFS_Context;
 

--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -16,7 +16,7 @@ encfs - mounts or creates an encrypted virtual filesystem
 
 =head1 SYNOPSIS
 
-B<encfs> [B<--version>] [B<-v>|B<--verbose>] [B<-t>|B<--syslogtag>] 
+B<encfs> [B<--version>] [B<-v>|B<--verbose>] [B<-c>|B<--config>] [B<-t>|B<--syslogtag>] 
 [B<-s>] [B<-f>] [B<--annotate>] [B<--standard>] [B<--paranoia>] 
 [B<--reverse>] [B<--reversewrite>] [B<--extpass=program>] [B<-S>|B<--stdinpass>] 
 [B<--anykey>] [B<--forcedecode>] [B<-require-macs>] 
@@ -47,6 +47,10 @@ may be an increasing number of choices.
 
 Shows B<EncFS> version.  Using B<--verbose> before B<--version> may display
 additional information.
+
+=item B<-c>, B<--config>
+
+Causes B<EncFS> to use the supplied file as the configuration file.
 
 =item B<-v>, B<--verbose>
 

--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -20,7 +20,7 @@ B<encfs> [B<--version>] [B<-v>|B<--verbose>] [B<-c>|B<--config>] [B<-t>|B<--sysl
 [B<-s>] [B<-f>] [B<--annotate>] [B<--standard>] [B<--paranoia>] 
 [B<--reverse>] [B<--reversewrite>] [B<--extpass=program>] [B<-S>|B<--stdinpass>] 
 [B<--anykey>] [B<--forcedecode>] [B<-require-macs>] 
-[B<-i MINUTES>|B<--idle=MINUTES>] [B<-m>|B<--ondemand>] [B<--delaymount>] 
+[B<-i MINUTES>|B<--idle=MINUTES>] [B<-m>|B<--ondemand>] [B<--delaymount>] [B<-u>|B<--unmount>] 
 [B<--public>] [B<--nocache>] [B<--no-default-flags>]
 [B<-o FUSE_OPTION>] [B<-d>|B<--fuse-debug>] [B<-H>|B<--fuse-help>] 
 I<rootdir> I<mountPoint> 
@@ -207,6 +207,10 @@ password.  If this succeeds, then the filesystem becomes available again.
 
 Do not mount the filesystem when encfs starts; instead, delay mounting until
 first use. This option only makes sense with B<--ondemand>.
+
+=item B<-u>, B<--unmount>
+
+Unmounts the specified I<mountPoint>.
 
 =item B<--public>
 

--- a/encfs/encfsctl.cpp
+++ b/encfs/encfsctl.cpp
@@ -164,7 +164,7 @@ static int showInfo(int argc, char **argv) {
   if (!checkDir(rootDir)) return EXIT_FAILURE;
 
   std::shared_ptr<EncFSConfig> config(new EncFSConfig);
-  ConfigType type = readConfig(rootDir, config.get());
+  ConfigType type = readConfig(rootDir, config.get(), "");
 
   // show information stored in config..
   switch (type) {
@@ -622,7 +622,7 @@ static int do_chpasswd(bool useStdin, bool annotate, bool checkOnly, int argc,
   if (!checkDir(rootDir)) return EXIT_FAILURE;
 
   EncFSConfig *config = new EncFSConfig;
-  ConfigType cfgType = readConfig(rootDir, config);
+  ConfigType cfgType = readConfig(rootDir, config, "");
 
   if (cfgType == Config_None) {
     cout << _("Unable to load or parse config file\n");
@@ -683,7 +683,7 @@ static int do_chpasswd(bool useStdin, bool annotate, bool checkOnly, int argc,
     config->assignKeyData(keyBuf, encodedKeySize);
     delete[] keyBuf;
 
-    if (saveConfig(cfgType, rootDir, config)) {
+    if (saveConfig(cfgType, rootDir, config, "")) {
       // password modified -- changes volume key of filesystem..
       cout << _("Volume Key successfully updated.\n");
       result = EXIT_SUCCESS;

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -28,10 +28,6 @@
 #include <pthread.h>
 #include <sstream>
 #include <string>
-#ifdef __APPLE__
-#include <sys/mount.h>
-#include <sys/param.h>
-#endif
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -609,12 +605,7 @@ int main(int argc, char *argv[]) {
 
   // Let's unmount if requested
   if (encfsArgs->opts->unmount) {
-    fuse_unmount(encfsArgs->opts->mountPoint.c_str(), nullptr);
-#ifdef __APPLE__
-    // fuse_unmount does not work on Mac OS, see #428
-    unmount(encfsArgs->opts->mountPoint.c_str(), MNT_FORCE);
-#endif
-    // fuse_unmount succeeds and returns void
+    unmountFS(encfsArgs->opts->mountPoint.c_str());
     cout << "Filesystem unmounting: " << encfsArgs->opts->mountPoint << endl;
     return 0;
   }

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -162,6 +162,8 @@ static void usage(const char *name) {
             "reverse encryption\n")
        << _("  --reversewrite\t\t"
             "reverse encryption with writes enabled\n")
+       << _("  -c, --config=path\t\t"
+            "specifies config file (overrides ENV variable)\n")
 
        // xgroup(usage)
        << _("  --extpass=program\tUse external program for password prompt\n"
@@ -255,6 +257,7 @@ static bool processArgs(int argc, char *argv[],
       {"standard", 0, nullptr, '1'},              // standard configuration
       {"paranoia", 0, nullptr, '2'},              // standard configuration
       {"require-macs", 0, nullptr, LONG_OPT_REQUIRE_MAC},  // require MACs
+      { "config", 1, nullptr, 'c'},               // command-line-supplied config location 
       {nullptr, 0, nullptr, 0}};
 
   while (true) {
@@ -269,8 +272,9 @@ static bool processArgs(int argc, char *argv[],
     // 'S' : password from stdin
     // 'o' : arguments meant for fuse
     // 't' : syslog tag
+    // 'c' : configuration file
     int res =
-        getopt_long(argc, argv, "HsSfvdmi:o:t:", long_options, &option_index);
+        getopt_long(argc, argv, "HsSfvdmi:o:t:c:", long_options, &option_index);
 
     if (res == -1) {
       break;
@@ -297,6 +301,11 @@ static bool processArgs(int argc, char *argv[],
         break;
       case LONG_OPT_REQUIRE_MAC:
         out->opts->requireMac = true;
+        break;
+      case 'c':
+        /* Take config file path from command 
+         * line instead of ENV variable */
+        out->opts->config.assign(optarg);
         break;
       case 'f':
         out->isDaemon = false;

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -615,7 +615,7 @@ int main(int argc, char *argv[]) {
     unmount(encfsArgs->opts->mountPoint.c_str(), MNT_FORCE);
 #endif
     // fuse_unmount succeeds and returns void
-    cerr << "Filesystem unmounting: " << encfsArgs->opts->mountPoint << endl;
+    cout << "Filesystem unmounting: " << encfsArgs->opts->mountPoint << endl;
     return 0;
   }
 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -28,6 +28,10 @@
 #include <pthread.h>
 #include <sstream>
 #include <string>
+#ifdef __APPLE__
+#include <sys/mount.h>
+#include <sys/param.h>
+#endif
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -164,6 +168,8 @@ static void usage(const char *name) {
             "reverse encryption with writes enabled\n")
        << _("  -c, --config=path\t\t"
             "specifies config file (overrides ENV variable)\n")
+       << _("  -u, --unmount\t\t"
+            "unmounts specified mountPoint\n")
 
        // xgroup(usage)
        << _("  --extpass=program\tUse external program for password prompt\n"
@@ -219,6 +225,7 @@ static bool processArgs(int argc, char *argv[],
   out->opts->annotate = false;
   out->opts->reverseEncryption = false;
   out->opts->requireMac = false;
+  out->opts->unmount = false;
 
   bool useDefaultFlags = true;
 
@@ -257,7 +264,8 @@ static bool processArgs(int argc, char *argv[],
       {"standard", 0, nullptr, '1'},              // standard configuration
       {"paranoia", 0, nullptr, '2'},              // standard configuration
       {"require-macs", 0, nullptr, LONG_OPT_REQUIRE_MAC},  // require MACs
-      { "config", 1, nullptr, 'c'},               // command-line-supplied config location 
+      {"config", 1, nullptr, 'c'},                // command-line-supplied config location
+      {"unmount", 1, nullptr, 'u'},               // unmount
       {nullptr, 0, nullptr, 0}};
 
   while (true) {
@@ -273,8 +281,9 @@ static bool processArgs(int argc, char *argv[],
     // 'o' : arguments meant for fuse
     // 't' : syslog tag
     // 'c' : configuration file
+    // 'u' : unmount
     int res =
-        getopt_long(argc, argv, "HsSfvdmi:o:t:c:", long_options, &option_index);
+        getopt_long(argc, argv, "HsSfvdmi:o:t:c:u", long_options, &option_index);
 
     if (res == -1) {
       break;
@@ -306,6 +315,9 @@ static bool processArgs(int argc, char *argv[],
         /* Take config file path from command 
          * line instead of ENV variable */
         out->opts->config.assign(optarg);
+        break;
+      case 'u':
+        out->opts->unmount = true;
         break;
       case 'f':
         out->isDaemon = false;
@@ -385,7 +397,7 @@ static bool processArgs(int argc, char *argv[],
         break;
       case 'P':
         if (geteuid() != 0) {
-          RLOG(WARNING) << "option '--public' ignored for non-root user";
+          cerr << "option '--public' ignored for non-root user";
         } else {
           out->opts->ownerCreate = true;
           // add 'allow_other' option
@@ -416,13 +428,24 @@ static bool processArgs(int argc, char *argv[],
         // missing parameter for option..
         break;
       default:
-        RLOG(WARNING) << "getopt error: " << res;
+        cerr << "getopt error: " << res;
         break;
     }
   }
 
   if (!out->isThreaded) {
     PUSHARG("-s");
+  }
+
+  // for --unmount, we should have exactly 1 argument - the mount point
+  if (out->opts->unmount) {
+    if (optind + 1 == argc) {
+      out->opts->mountPoint = slashTerminate(argv[optind++]);
+      return true;
+    }
+    // no mount point specified
+    cerr << _("Expecting one argument, aborting.") << endl;
+    return false;
   }
 
   // we should have at least 2 arguments left over - the source directory and
@@ -434,7 +457,7 @@ static bool processArgs(int argc, char *argv[],
     out->opts->mountPoint = slashTerminate(argv[optind++]);
   } else {
     // no mount point specified
-    cerr << _("Missing one or more arguments, aborting.");
+    cerr << _("Missing one or more arguments, aborting.") << endl;
     return false;
   }
 
@@ -582,6 +605,18 @@ int main(int argc, char *argv[]) {
   if (argc == 1 || !processArgs(argc, argv, encfsArgs)) {
     usage(argv[0]);
     return EXIT_FAILURE;
+  }
+
+  // Let's unmount if requested
+  if (encfsArgs->opts->unmount) {
+    fuse_unmount(encfsArgs->opts->mountPoint.c_str(), nullptr);
+#ifdef __APPLE__
+    // fuse_unmount does not work on Mac OS, see #428
+    unmount(encfsArgs->opts->mountPoint.c_str(), MNT_FORCE);
+#endif
+    // fuse_unmount succeeds and returns void
+    cerr << "Filesystem unmounting: " << encfsArgs->opts->mountPoint << endl;
+    return 0;
   }
 
   encfs::initLogging(encfsArgs->isVerbose, encfsArgs->isDaemon);

--- a/integration/common.pl
+++ b/integration/common.pl
@@ -2,13 +2,7 @@
 # works on Linux AND OSX
 sub portable_unmount {
     my $crypt = shift;
-    my $fusermount = qx(which fusermount);
-    chomp($fusermount);
-    if(-f $fusermount) {
-        qx($fusermount -u "$crypt");
-    } else {
-        qx(umount "$crypt");
-    }
+    qx(./build/encfs -u "$crypt");
 }
 
 # Helper function

--- a/integration/common.pl
+++ b/integration/common.pl
@@ -2,7 +2,7 @@
 # works on Linux AND OSX
 sub portable_unmount {
     my $crypt = shift;
-    qx(./build/encfs -u "$crypt");
+    qx(./build/encfs -u "$crypt" >/dev/null);
 }
 
 # Helper function

--- a/integration/normal.t.pl
+++ b/integration/normal.t.pl
@@ -436,8 +436,9 @@ sub create_unmount_remount
     # Unmount
     portable_unmount($mnt);
 
-    # Mount again
-    system("./build/encfs --extpass=\"echo test\" $crypt $mnt 2>&1");
+    # Mount again, testing -c as the same time
+    rename("$crypt/.encfs6.xml", "$crypt/.encfs6_moved.xml");
+    system("./build/encfs -c $crypt/.encfs6_moved.xml --extpass=\"echo test\" $crypt $mnt 2>&1");
     ok( $? == 0, "encfs command returns 0") || return;
 
     # Check if content is still there


### PR DESCRIPTION
Hi,

This PR adds 2 new command line options :
- -c / --config : causes EncFS to use the supplied file as the configuration file ;
- -u / --unmount : unmounts the supplied mount point.

This is in some kind a rework of #167.

This PR should also close #428.

Thank you 👍 

Ben