### PR TITLE
 Add ability to disable file data encoding

### DIFF
--- a/encfs/FSConfig.h
+++ b/encfs/FSConfig.h
@@ -67,6 +67,8 @@ struct EncFSConfig {
   int kdfIterations;
   long desiredKDFDuration;
 
+  bool plainData;         // do not encrypt file content
+
   int blockMACBytes;      // MAC headers on blocks..
   int blockMACRandBytes;  // number of random bytes in the block header
 
@@ -79,6 +81,7 @@ struct EncFSConfig {
   EncFSConfig() : keyData(), salt() {
     cfgType = Config_None;
     subVersion = 0;
+    plainData = false;
     blockMACBytes = 0;
     blockMACRandBytes = 0;
     uniqueIV = false;

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -880,11 +880,11 @@ static bool boolDefaultYes(const char *prompt) {
 /**
  * Ask the user to select plain data
  */
-static bool selectPlainData(bool unsafe) {
+static bool selectPlainData(bool insecure) {
   bool plainData = false;
-  if (unsafe) {
+  if (insecure) {
     plainData = boolDefaultNo(
-        _("You used --unsafe, you can then disable file data encryption\n"
+        _("You used --insecure, you can then disable file data encryption\n"
            "which is of course abolutely discouraged.\n"
            "Disable file data encryption?"));
   }
@@ -1117,7 +1117,7 @@ RootPtr createV6Config(EncFS_Context *ctx,
     alg = selectCipherAlgorithm();
     keySize = selectKeySize(alg);
     blockSize = selectBlockSize(alg);
-    plainData = selectPlainData(opts->unsafe);
+    plainData = selectPlainData(opts->insecure);
     nameIOIface = selectNameCoding();
     if (plainData) {
       cout << _("plain data - IV, MAC and file-hole disabled") << "\n";
@@ -1701,8 +1701,8 @@ RootPtr initFS(EncFS_Context *ctx, const std::shared_ptr<EncFS_Opts> &opts) {
 
     FSConfigPtr fsConfig(new FSConfig);
     if (config->plainData) {
-      if (! opts->unsafe) {
-        cout << _("Configuration use plainData but you did not use --unsafe\n");
+      if (! opts->insecure) {
+        cout << _("Configuration use plainData but you did not use --insecure\n");
         return rootInfo;
       }
       static Interface NullInterface("nullCipher", 1, 0, 0);

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -884,9 +884,9 @@ static bool selectPlainData(bool unsafe) {
   bool plainData = false;
   if (unsafe) {
     plainData = boolDefaultNo(
-        _("You used --unsafe, you can then disable file data encoding\n"
+        _("You used --unsafe, you can then disable file data encryption\n"
            "which is of course abolutely discouraged.\n"
-           "Disable file data encoding?"));
+           "Disable file data encryption?"));
   }
   return plainData;
 }

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -96,7 +96,7 @@ struct EncFS_Opts {
 
   bool readOnly;  // Mount read-only
 
-  bool unsafe; // Allow to use plain data / to disable data encoding
+  bool insecure; // Allow to use plain data / to disable data encoding
 
   bool requireMac;  // Throw an error if MAC is disabled
 
@@ -118,7 +118,7 @@ struct EncFS_Opts {
     configMode = Config_Prompt;
     noCache = false;
     readOnly = false;
-    unsafe = false;
+    insecure = false;
     requireMac = false;
   }
 };

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -96,6 +96,8 @@ struct EncFS_Opts {
 
   bool readOnly;  // Mount read-only
 
+  bool unsafe; // Allow to use plain data / to disable data encoding
+
   bool requireMac;  // Throw an error if MAC is disabled
 
   ConfigMode configMode;
@@ -116,6 +118,7 @@ struct EncFS_Opts {
     configMode = Config_Prompt;
     noCache = false;
     readOnly = false;
+    unsafe = false;
     requireMac = false;
   }
 };

--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -17,7 +17,7 @@ encfs - mounts or creates an encrypted virtual filesystem
 =head1 SYNOPSIS
 
 B<encfs> [B<--version>] [B<-v>|B<--verbose>] [B<-c>|B<--config>] [B<-t>|B<--syslogtag>] 
-[B<-s>] [B<-f>] [B<--annotate>] [B<--standard>] [B<--paranoia>] [B<--unsafe>] 
+[B<-s>] [B<-f>] [B<--annotate>] [B<--standard>] [B<--paranoia>] [B<--insecure>] 
 [B<--reverse>] [B<--reversewrite>] [B<--extpass=program>] [B<-S>|B<--stdinpass>] 
 [B<--anykey>] [B<--forcedecode>] [B<-require-macs>] 
 [B<-i MINUTES>|B<--idle=MINUTES>] [B<-m>|B<--ondemand>] [B<--delaymount>] [B<-u>|B<--unmount>] 
@@ -97,7 +97,7 @@ When not creating a filesystem, this flag does nothing.
 
 Same as B<--standard>, but for B<paranoia> mode.
 
-=item B<--unsafe>
+=item B<--insecure>
 
 Allows you to disable data encoding, thus to pass plain data as is.  Fully
 discouraged of course!

--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -17,7 +17,7 @@ encfs - mounts or creates an encrypted virtual filesystem
 =head1 SYNOPSIS
 
 B<encfs> [B<--version>] [B<-v>|B<--verbose>] [B<-c>|B<--config>] [B<-t>|B<--syslogtag>] 
-[B<-s>] [B<-f>] [B<--annotate>] [B<--standard>] [B<--paranoia>] 
+[B<-s>] [B<-f>] [B<--annotate>] [B<--standard>] [B<--paranoia>] [B<--unsafe>] 
 [B<--reverse>] [B<--reversewrite>] [B<--extpass=program>] [B<-S>|B<--stdinpass>] 
 [B<--anykey>] [B<--forcedecode>] [B<-require-macs>] 
 [B<-i MINUTES>|B<--idle=MINUTES>] [B<-m>|B<--ondemand>] [B<--delaymount>] [B<-u>|B<--unmount>] 
@@ -96,6 +96,11 @@ When not creating a filesystem, this flag does nothing.
 =item B<--paranoia>
 
 Same as B<--standard>, but for B<paranoia> mode.
+
+=item B<--unsafe>
+
+Allows you to disable data encoding, thus to pass plain data as is.  Fully
+discouraged of course!
 
 =item B<--reverse>
 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -48,7 +48,7 @@
 #define LONG_OPT_ANNOTATE 513
 #define LONG_OPT_NOCACHE 514
 #define LONG_OPT_REQUIRE_MAC 515
-#define LONG_OPT_UNSAFE 516
+#define LONG_OPT_INSECURE 516
 
 using namespace std;
 using namespace encfs;
@@ -222,7 +222,7 @@ static bool processArgs(int argc, char *argv[],
   out->opts->annotate = false;
   out->opts->reverseEncryption = false;
   out->opts->requireMac = false;
-  out->opts->unsafe = false;
+  out->opts->insecure = false;
   out->opts->unmount = false;
 
   bool useDefaultFlags = true;
@@ -262,7 +262,7 @@ static bool processArgs(int argc, char *argv[],
       {"standard", 0, nullptr, '1'},              // standard configuration
       {"paranoia", 0, nullptr, '2'},              // standard configuration
       {"require-macs", 0, nullptr, LONG_OPT_REQUIRE_MAC},  // require MACs
-      {"unsafe", 0, nullptr, LONG_OPT_UNSAFE},    // allows to use null data encryption
+      {"insecure", 0, nullptr, LONG_OPT_INSECURE},// allows to use null data encryption
       {"config", 1, nullptr, 'c'},                // command-line-supplied config location
       {"unmount", 1, nullptr, 'u'},               // unmount
       {nullptr, 0, nullptr, 0}};
@@ -310,8 +310,8 @@ static bool processArgs(int argc, char *argv[],
       case LONG_OPT_REQUIRE_MAC:
         out->opts->requireMac = true;
         break;
-      case LONG_OPT_UNSAFE:
-        out->opts->unsafe = true;
+      case LONG_OPT_INSECURE:
+        out->opts->insecure = true;
         break;
       case 'c':
         /* Take config file path from command 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -262,7 +262,7 @@ static bool processArgs(int argc, char *argv[],
       {"standard", 0, nullptr, '1'},              // standard configuration
       {"paranoia", 0, nullptr, '2'},              // standard configuration
       {"require-macs", 0, nullptr, LONG_OPT_REQUIRE_MAC},  // require MACs
-      {"unsafe", 0, nullptr, LONG_OPT_UNSAFE},  // require MACs
+      {"unsafe", 0, nullptr, LONG_OPT_UNSAFE},    // allows to use null data encryption
       {"config", 1, nullptr, 'c'},                // command-line-supplied config location
       {"unmount", 1, nullptr, 'u'},               // unmount
       {nullptr, 0, nullptr, 0}};

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -48,6 +48,7 @@
 #define LONG_OPT_ANNOTATE 513
 #define LONG_OPT_NOCACHE 514
 #define LONG_OPT_REQUIRE_MAC 515
+#define LONG_OPT_UNSAFE 516
 
 using namespace std;
 using namespace encfs;
@@ -221,6 +222,7 @@ static bool processArgs(int argc, char *argv[],
   out->opts->annotate = false;
   out->opts->reverseEncryption = false;
   out->opts->requireMac = false;
+  out->opts->unsafe = false;
   out->opts->unmount = false;
 
   bool useDefaultFlags = true;
@@ -260,6 +262,7 @@ static bool processArgs(int argc, char *argv[],
       {"standard", 0, nullptr, '1'},              // standard configuration
       {"paranoia", 0, nullptr, '2'},              // standard configuration
       {"require-macs", 0, nullptr, LONG_OPT_REQUIRE_MAC},  // require MACs
+      {"unsafe", 0, nullptr, LONG_OPT_UNSAFE},  // require MACs
       {"config", 1, nullptr, 'c'},                // command-line-supplied config location
       {"unmount", 1, nullptr, 'u'},               // unmount
       {nullptr, 0, nullptr, 0}};
@@ -306,6 +309,9 @@ static bool processArgs(int argc, char *argv[],
         break;
       case LONG_OPT_REQUIRE_MAC:
         out->opts->requireMac = true;
+        break;
+      case LONG_OPT_UNSAFE:
+        out->opts->unsafe = true;
         break;
       case 'c':
         /* Take config file path from command 

--- a/integration/normal.t.pl
+++ b/integration/normal.t.pl
@@ -441,7 +441,7 @@ sub create_unmount_remount
     # Unmount
     portable_unmount($mnt);
 
-    # Mount again, testing -c as the same time
+    # Mount again, testing -c at the same time
     rename("$crypt/.encfs6.xml", "$crypt/.encfs6_moved.xml");
     system("./build/encfs -c $crypt/.encfs6_moved.xml --extpass=\"echo test\" $crypt $mnt 2>&1");
     ok( $? == 0, "encfs command returns 0") || return;


### PR DESCRIPTION
Hi,

This PR closes #481 adding the ability to disable file data encoding a FS creation.
Note that this must be enabled by adding the new option `--unsafe`.
And must be enforced at mount by `--unsafe`.
User then knows !

Many thx 👍 

Ben