### PR TITLE
Correct a small issue in recodePath

### DIFF
--- a/encfs/NameIO.cpp
+++ b/encfs/NameIO.cpp
@@ -146,8 +146,8 @@ std::string NameIO::recodePath(
   string output;
 
   while (*path != 0) {
-    if (*path == '/') {
-      if (!output.empty()) {  // don't start the string with '/'
+    if (*path == '/' || *path == '+') {
+      if (!output.empty()) {  // don't start the string with '/' (and also drop the trailing '+')
         output += '/';
       }
       ++path;

--- a/encfs/encfsctl.cpp
+++ b/encfs/encfsctl.cpp
@@ -429,11 +429,6 @@ static int cmd_cat(int argc, char **argv) {
   if (!rootInfo) return EXIT_FAILURE;
 
   const char *path = argv[0];
-  // If user provides a leading slash, in reverse mode, it will be converted
-  // to "+" by plainpath, and will fail to decode... Workaround below then...
-  if (path[0] == '/') {
-    path++;
-  }
   WriteOutput output(STDOUT_FILENO);
   int errCode = processContents(rootInfo, path, output);
 


### PR DESCRIPTION
Hi,

This PR corrects a small issue in recodePath, where a path to decode could begin with a trailing '+' (trailing '/' are encoded to '+').
It then revert 154839d67c9b7504687bcc2301fd2782ff9f3368 which is no more needed, this solution is much generic / much nicer.

This has been found adding `encfsctl --reverse cat`, where a user could provide a path beginning with a trailing '/'.

Thank you 👍 

Ben