### PR TITLE
Cygwin, better handle read-only FS

### DIFF
--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -605,6 +605,14 @@ void *encfs_init(fuse_conn_info *conn) {
   // set fuse connection options
   conn->async_read = 1u;
 
+#ifdef __CYGWIN__
+  // WinFsp needs this to partially handle read-only FS
+  // See https://github.com/billziss-gh/winfsp/issues/157 for details
+  if (ctx->opts->readOnly) {
+    conn->want |= (conn->capable & FSP_FUSE_CAP_READ_ONLY);
+  }
+#endif
+
   // if an idle timeout is specified, then setup a thread to monitor the
   // filesystem.
   if (ctx->args->idleTimeout > 0) {

--- a/integration/normal.t.pl
+++ b/integration/normal.t.pl
@@ -329,7 +329,7 @@ sub links
 {
     my $hardlinkTests = shift;
 
-    my $contents = "hello world\n";
+    my $contents = "hello world";
     ok( open(OUT, "> $crypt/data"), "create file for link test" );
     print OUT $contents;
     close OUT;

--- a/integration/reverse.t.pl
+++ b/integration/reverse.t.pl
@@ -141,7 +141,7 @@ sub symlink_test
 {
     my $target = shift;
     ok(symlink($target, "$plain/symlink"), "Symlink create, $plain/symlink -> $target");
-    ok(my $dec = readlink("$decrypted/symlink"), "Symlink read, $decrypted/symlink");
+    ok(my $dec = readlink("$decrypted/symlink"), "Symlink read, $decrypted/symlink -> $target");
     $dec.="";
     ok($dec eq $target, "Symlink compare, '$target' != '$dec'");
     my $return_code = ($have_xattr) ? system(@binattr, "$decrypted/symlink") : 0;


### PR DESCRIPTION
Hi,

This PR allows to better handle read-only FS in Cygwin.

When a FS is read-only, files deletion will not return error, however files will not thankfully be deleted.
This PR then makes Cygwin `rm` to correctly return a `read-only filesystem` error.
It does not however help with Windows explorer for now, as described in https://github.com/billziss-gh/winfsp/issues/157.

And 2 small cosmetic changes in integration tests I had in queue...

Thx  !

Ben