### PR TITLE
Exit idleMonitor thread when it has finished

### DIFF
--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -842,7 +842,6 @@ static void *idleMonitor(void *_arg) {
   while (ctx->running) {
     unmountres = ctx->usageAndUnmount(timeoutCycles);
     if (unmountres) {
-      pthread_cond_wait(&ctx->wakeupCond, &ctx->wakeupMutex);
       break;
     }
 


### PR DESCRIPTION
Hi,

This PR makes the idleMonitor thread to exit as soon as it has finished.
This could help in debugging situations such as #470.

Thank you !

Ben