### PR TITLE
Cygwin, set proper installation prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ if (NOT DEFINED LIB_INSTALL_DIR)
   set (LIB_INSTALL_DIR lib)
 endif ()
 
+if (CYGWIN)
+  set (CMAKE_INSTALL_PREFIX /usr)
+endif()
+
 # We need C++ 11
 if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.0)
   # CMake 3.1 has built-in CXX standard checks.


### PR DESCRIPTION
Hi,

This PR simply sets a proper installation prefix for Cygwin.
Then, binaries are next to Cygwin DLLs, which is easier for the user running EncFS out of a Cygwin console.

Thx 👍 

Ben