### PR TITLE
Cygwin, support Windows-style parameter paths

### DIFF
--- a/encfs/Context.cpp
+++ b/encfs/Context.cpp
@@ -116,7 +116,7 @@ bool EncFS_Context::usageAndUnmount(int timeoutCycles) {
     if (!openFiles.empty()) {
       if (idleCount % timeoutCycles == 0) {
         RLOG(WARNING) << "Filesystem inactive, but " << openFiles.size()
-                      << " files opened: " << this->opts->mountPoint;
+                      << " files opened: " << this->opts->unmountPoint;
       }
       return false;
     }

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -1749,7 +1749,7 @@ void unmountFS(const char *mountPoint) {
   pid_t pid;
   int status;
   if ((pid = fork()) == 0) {
-    execl("/usr/bin/pkill", "/usr/bin/pkill", "-INT", "-f", string("(^|/)encfs .*/.* ").append(mountPoint).append("?( |$)").c_str(), (char *)0);
+    execl("/bin/pkill", "/bin/pkill", "-INT", "-if", string("(^|/)encfs .*(/|.:).* ").append(mountPoint).append("( |$)").c_str(), (char *)0);
     int eno = errno;
     RLOG(ERROR) << "Filesystem unmount failed: " << strerror(eno);
     _Exit(127);
@@ -1775,14 +1775,14 @@ int remountFS(EncFS_Context *ctx) {
 bool unmountFS(EncFS_Context *ctx) {
   if (ctx->opts->mountOnDemand) {
     VLOG(1) << "Detaching filesystem due to inactivity: "
-            << ctx->opts->mountPoint;
+            << ctx->opts->unmountPoint;
 
     ctx->setRoot(std::shared_ptr<DirNode>());
     return false;
   }
   // Time to unmount!
-  RLOG(INFO) << "Filesystem inactive, unmounting: " << ctx->opts->mountPoint;
-  unmountFS(ctx->opts->mountPoint.c_str());
+  RLOG(INFO) << "Filesystem inactive, unmounting: " << ctx->opts->unmountPoint;
+  unmountFS(ctx->opts->unmountPoint.c_str());
   return true;
 }
 

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -72,6 +72,7 @@ enum ConfigMode { Config_Prompt, Config_Standard, Config_Paranoia };
 struct EncFS_Opts {
   std::string rootDir;
   std::string mountPoint;  // where to make filesystem visible
+  std::string unmountPoint;// same as mountPoint, but as given by the user
   std::string cygDrive;    // Cygwin mount drive
   bool createIfNotFound;   // create filesystem if not found
   bool idleTracking;       // turn on idle monitoring of filesystem


### PR DESCRIPTION
Hi,

This PR enables the use of Windows-style paths as parameters.
Now, user can use for example :
`encfs C:\cipher X:`

Thank you 👍 

Ben