### PR TITLE
Cygwin, support Windows-style parameter paths, typo

### DIFF
--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -484,7 +484,7 @@ static bool processArgs(int argc, char *argv[],
     // rest of the code.
     out->opts->rootDir = slashTerminate(argv[optind++]);
     out->opts->unmountPoint = string(argv[optind++]);
-    out->opts->mountPoint = slashTerminate(out->opts->unmountPoint.c_str());
+    out->opts->mountPoint = slashTerminate(out->opts->unmountPoint);
   } else {
     // no mount point specified
     cerr << _("Missing one or more arguments, aborting.") << endl;


### PR DESCRIPTION
Hi,

This PR corrects a readability-redundant-string-cstr typo detected by clang, introduced in #510 / https://github.com/vgough/encfs/commit/6c1fde25fceb43be7401821fe56c2252cfdfb365.

Thx 👍 

Ben