### PR TITLE
Cygwin, set proper installation prefix, but don't force

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,9 @@ if (NOT DEFINED LIB_INSTALL_DIR)
 endif ()
 
 if (CYGWIN)
-  set (CMAKE_INSTALL_PREFIX /usr)
+  if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set (CMAKE_INSTALL_PREFIX /usr)
+  endif()
 endif()
 
 # We need C++ 11


### PR DESCRIPTION
Hi,

This PR is related to #509.
It avoid forcing an installation path if already set by the user.

Thx 👍 

Ben