### PR TITLE
Correct a sign-compare warning

### DIFF
--- a/encfs/BlockFileIO.cpp
+++ b/encfs/BlockFileIO.cpp
@@ -186,7 +186,7 @@ ssize_t BlockFileIO::read(const IORequest &req) const {
     ++blockNum;
     partialOffset = 0;
 
-    if (readSize < _blockSize) {
+    if ((size_t)readSize < _blockSize) {
       break;
     }
   }


### PR DESCRIPTION
Hi,

This PR corrects a compilation warning fired by Cygwin 32 bits !

Thx 👍 

Ben