### PR TITLE
Handle CBC padding

### DIFF
--- a/encfs/BlockFileIO.cpp
+++ b/encfs/BlockFileIO.cpp
@@ -43,7 +43,7 @@ static void clearCache(IORequest &req, unsigned int blockSize) {
 BlockFileIO::BlockFileIO(unsigned int blockSize, const FSConfigPtr &cfg)
     : _blockSize(blockSize), _allowHoles(cfg->config->allowHoles) {
   CHECK(_blockSize > 1);
-  _cache.data = new unsigned char[_blockSize + 1]; // we will need some room for padding
+  _cache.data = new unsigned char[_blockSize + 16]; // we will need some room for padding
   _noCache = cfg->opts->noCache;
 }
 

--- a/encfs/BlockFileIO.cpp
+++ b/encfs/BlockFileIO.cpp
@@ -43,7 +43,7 @@ static void clearCache(IORequest &req, unsigned int blockSize) {
 BlockFileIO::BlockFileIO(unsigned int blockSize, const FSConfigPtr &cfg)
     : _blockSize(blockSize), _allowHoles(cfg->config->allowHoles) {
   CHECK(_blockSize > 1);
-  _cache.data = new unsigned char[_blockSize];
+  _cache.data = new unsigned char[_blockSize + 1]; // we will need some room for padding
   _noCache = cfg->opts->noCache;
 }
 

--- a/encfs/BlockFileIO.h
+++ b/encfs/BlockFileIO.h
@@ -62,6 +62,7 @@ class BlockFileIO : public FileIO {
   unsigned int _blockSize;
   bool _allowHoles;
   bool _noCache;
+  bool _cachePartialWrite;
 
   // cache last block for speed...
   mutable IORequest _cache;

--- a/encfs/CipherFileIO.cpp
+++ b/encfs/CipherFileIO.cpp
@@ -64,8 +64,8 @@ const int HEADER_SIZE = 8;  // 64 bit initialization vector..
  * blockSize = blockSize - 1 in normal mode.
  */
 PaddingType checkCBCPadding(const FSConfigPtr &cfg) {
-  if (((cfg->config->cipherIface.current() == 3) && (cfg->config->cipherIface.revision() >= 1)) ||
-      (cfg->config->cipherIface.current() > 3)) {
+  if ((((cfg->config->cipherIface.current() == 3) && (cfg->config->cipherIface.revision() >= 1)) ||
+       (cfg->config->cipherIface.current() > 3)) && (cfg->config->padding)) {
     if (cfg->reverseEncryption) {
       return Padding_Reverse;
     }

--- a/encfs/CipherFileIO.h
+++ b/encfs/CipherFileIO.h
@@ -38,6 +38,8 @@ class Cipher;
 class FileIO;
 struct IORequest;
 
+enum PaddingType { Padding_Disabled, Padding_Normal, Padding_Reverse };
+
 /*
     Implement the FileIO interface encrypting data in blocks.
 

--- a/encfs/CipherFileIO.h
+++ b/encfs/CipherFileIO.h
@@ -77,6 +77,9 @@ class CipherFileIO : public BlockFileIO {
   bool blockWrite(unsigned char *buf, int size, uint64_t iv64) const;
   bool streamWrite(unsigned char *buf, int size, uint64_t iv64) const;
 
+  void plainSizeToCipherSize(off_t *size) const;
+  void cipherSizeToPlainSize(off_t *size) const;
+
   ssize_t read(const IORequest &req) const;
 
   std::shared_ptr<FileIO> base;

--- a/encfs/CipherFileIO.h
+++ b/encfs/CipherFileIO.h
@@ -90,6 +90,7 @@ class CipherFileIO : public BlockFileIO {
 
   std::shared_ptr<Cipher> cipher;
   CipherKey key;
+  bool haveCBCPadding;
 };
 
 }  // namespace encfs

--- a/encfs/FSConfig.h
+++ b/encfs/FSConfig.h
@@ -69,6 +69,8 @@ struct EncFSConfig {
 
   bool plainData;         // do not encrypt file content
 
+  bool padding;           // use CBC padding instead of cipher stream mode
+
   int blockMACBytes;      // MAC headers on blocks..
   int blockMACRandBytes;  // number of random bytes in the block header
 
@@ -82,6 +84,7 @@ struct EncFSConfig {
     cfgType = Config_None;
     subVersion = 0;
     plainData = false;
+    padding = true;
     blockMACBytes = 0;
     blockMACRandBytes = 0;
     uniqueIV = false;

--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -1054,7 +1054,7 @@ RootPtr createV6Config(EncFS_Context *ctx,
   bool uniqueIV = true;         // selectUniqueIV()
   bool chainedIV = true;        // selectChainedIV()
   bool externalIV = false;      // selectExternalChainedIV()
-  bool allowHoles = true;       // selectZeroBlockPassThrough()
+  bool allowHoles = false;       // selectZeroBlockPassThrough()
   long desiredKDFDuration = NormalKDFDuration;
 
   if (reverseEncryption) {

--- a/encfs/SSL_Cipher.cpp
+++ b/encfs/SSL_Cipher.cpp
@@ -159,9 +159,9 @@ int TimedPBKDF2(const char *pass, int passlen, const unsigned char *salt,
 // - Version 2:1 adds support for Message Digest function interface
 // - Version 2:2 adds PBKDF2 for password derivation
 // - Version 3:0 adds a new IV mechanism
-static Interface BlowfishInterface("ssl/blowfish", 3, 0, 2);
-static Interface AESInterface("ssl/aes", 3, 0, 2);
-static Interface CAMELLIAInterface("ssl/camellia", 3, 0, 2);
+static Interface BlowfishInterface("ssl/blowfish", 3, 1, 2);
+static Interface AESInterface("ssl/aes", 3, 1, 2);
+static Interface CAMELLIAInterface("ssl/camellia", 3, 1, 2);
 
 #ifndef OPENSSL_NO_CAMELLIA
 

--- a/encfs/encfs.pod
+++ b/encfs/encfs.pod
@@ -419,7 +419,9 @@ In the expert / manual configuration mode, each of the above options is
 configurable.  Here is a list of current options with some notes about what
 they mean:
 
-=head1 Key Derivation Function
+=over 4
+
+=item I<Key Derivation Function (and generation time)>
 
 As of version 1.5, B<EncFS> now uses PBKDF2 as the default key derivation
 function.  The number of iterations in the keying function is selected based on
@@ -436,9 +438,7 @@ If an B<EncFS> filesystem configuration from 1.4.x is modified with version 1.5
 function will be used and the filesystem will no longer be readable by older
 versions.
 
-=over 4
-
-=item I<Cipher>
+=item I<Cipher Algorithms>
 
 Which encryption algorithm to use.  The list is generated automatically based
 on what supported algorithms B<EncFS> found in the encryption libraries.
@@ -457,9 +457,8 @@ default) is probably overkill.
 =item I<Filesystem Block Size>
 
 This is the size (in bytes) that B<EncFS> deals with at one time.  Each block
-gets its own initialization vector and is encoded in the cipher's
-cipher-block-chaining mode.  A partial block at the end of a file is encoded
-using a stream mode to avoid having to store the filesize somewhere.
+is padded (see below), gets its own initialization vector, and is encoded in
+the cipher's cipher-block-chaining mode.
 
 Having larger block sizes reduces the overhead of B<EncFS> a little, but it can
 also add overhead if your programs read small parts of files.  In order to read
@@ -468,9 +467,22 @@ read and decoded, so a large block size adds overhead to small requests.  With
 write calls it is even worse, as a block must be read and decoded, the change
 applied and the block encoded and written back out.
 
-The default is 512 bytes as of version 1.0.  It was hard coded to 64 bytes in
-version 0.x, which was not as efficient as the current setting for general
-usage.
+The default is 1024 bytes as of version 1.4.2 (512 bytes as of version 1.0).
+It was hard coded to 64 bytes in version 0.x, which was not as efficient as
+the current setting for general usage.
+
+=item I<Padding>
+
+As of 1.9.6, every block is padded with 1 byte before being encrypted in
+CBC (cipher-block-chaining) mode.  The last block is padded with the cipher
+block sier (16 bytes with AES).  This allows to compute the filesize without
+having to store it somewhere.  This however has a cost, in bytes,
+for files > 0 byte : int((fileSize - 1) / (blockSize - 1)) + cipherBlockSize.
+
+Previous behavior was to use cipher stream mode for the last partial block,
+without any padding.  This also avoids to have to store the filesize, and has
+no impact on it.  However, it is known to have some potential security issue.
+This can still be enabled in expert mode.
 
 =item I<Filename Encoding>
 

--- a/integration/reverse.t.pl
+++ b/integration/reverse.t.pl
@@ -178,7 +178,7 @@ sub grow {
         # autoflush should make sure the write goes to the kernel
         # immediately. Just to be sure, check it here.
         sizeVerify($vfh, $i) or die("unexpected plain file size");
-        sizeVerify($cfh, $i) or $ok = 0;
+        sizeVerify($cfh, $i + int(($i - 1) / 1023) + 16) or $ok = 0;
         sizeVerify($dfh, $i) or $ok = 0;
         
         if(md5fh($vfh) ne md5fh($dfh))
@@ -204,7 +204,7 @@ sub largeRead {
     my $cname = encName("largeRead");
     # cfh ... ciphertext file handle
     ok(open(my $cfh, "<", "$ciphertext/$cname"), "open ciphertext largeRead file");
-    ok(sizeVerify($cfh, 1024*1024), "1M file size");
+    ok(sizeVerify($cfh, (1024 * 1024) + int((1024 * 1024 - 1) / 1023) + 16), "1M file size");
 }
 
 # Check that the reverse mount is read-only


### PR DESCRIPTION
Hi,

This PR handles CBC padding, to get rid of cipher stream mode in the last data block.
This then closes #9 (and as a result closes #10), thus increasing EncFS security level.

Padding scheme is the one recently discussed in #9, and is detailed in the first commit of this PR.

Of course CBC padding is enabled for newly created filesystems, older ones will still use stream mode, for compatibility purpose.

I'm working on reverse write, but all other modes (read/write in normal mode, read in reverse mode) are already working, so that you can test & review the achieved work.

Thank you :+1: 

Ben