### PR TITLE
Add error message on failing to create config

### DIFF
--- a/encfs/FileUtils.cpp
+++ b/encfs/FileUtils.cpp
@@ -1247,6 +1247,7 @@ RootPtr createV6Config(EncFS_Context *ctx,
   }
 
   if (!saveConfig(Config_V6, rootDir, config.get(), opts->config)) {
+    cout << _("Error saving config file.\n");
     return rootInfo;
   }
 


### PR DESCRIPTION
Hi, it took me a while to realize why I couldn't create a reverse mapping from a folder where I only have read permissions because no error is printed:
```
$ mkdir test0 test1
$ chmod -w test0
$ encfs --reverse $(pwd)/test0 $(pwd)/test1
[...]
New Encfs Password: 
Verify Encfs Password: 
$
```

This commit adds one:
```
$ encfs --reverse $(pwd)/test0 $(pwd)/test1
[...]
New Encfs Password: 
Verify Encfs Password: 
Error saving config file.
$
```

