### PR TITLE
Use /bin/sh as a fallback to SHELL in encfssh

### DIFF
--- a/encfs/encfssh
+++ b/encfs/encfssh
@@ -77,7 +77,7 @@ fuse_umount() {
 }
 
 # Honor the SHELL environment variable to select a shell to run
-"$SHELL"; retval=$?
+"${SHELL:-/bin/sh}"; retval=$?
 
 # ensure that this shell isn't itself holding the mounted directory open
 # ...but avoid terminating on failure, *or* causing a shellcheck warning for


### PR DESCRIPTION
Currently if `$SHELL` is not set by any reason (e.g. `env -i`) the `encfssh` script will throw an `/usr/bin/encfssh: line 80: : Permission denied` error, which is quite misleading. This PR corrects that by using `/bin/sh` by default when `$SHELL` is not available.