### PR TITLE
Add an uptodate build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,44 +4,54 @@ matrix:
   include:
     - os: linux
       compiler: gcc
-      dist: trusty
+      dist: bionic
       sudo: required
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
             - attr
             - fuse
             - libfuse-dev
             - gettext
-            - cmake3
+            - cmake
+      env:
+        - SUDO_TESTS=true
+
+    - os: linux
+      compiler: gcc
+      dist: xenial
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - attr
+            - fuse
+            - libfuse-dev
+            - gettext
+            - cmake
       env:
         - SUDO_TESTS=true
 
     - os: linux
       compiler: clang
-      dist: trusty
+      dist: xenial
       sudo: false
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
           packages:
             - attr
             - fuse
             - libfuse-dev
             - gettext
-            - cmake3
+            - cmake
             - clang-4.0
             - clang-tidy-4.0
       env:
-        - CC=clang-4.0 CXX=clang++-4.0 CHECK=true INTEGRATION=false CMAKE=/tmp/bin/cmake
+        - CC=clang-4.0 CXX=clang++-4.0 CHECK=true INTEGRATION=false
 
     - os: osx
       compiler: clang
-      osx_image: xcode9
+      osx_image: xcode9.2
       sudo: required
       env:
         - SUDO_TESTS=true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,30 +196,26 @@ if (ENABLE_NLS)
   add_definitions(-DLOCALEDIR="${CMAKE_INSTALL_PREFIX}/share/locale")
 endif (ENABLE_NLS)
 
-if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.5) # Need 3.6 or above.
-  find_program(CLANG_TIDY_EXE NAMES "clang-tidy-4.0" "clang-tidy40" "clang-tidy" DOC "Path to clang-tidy executable")
-  if(NOT CLANG_TIDY_EXE)
-    message(STATUS "clang-tidy not found.")
-  else()
-    message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-    string(CONCAT TIDY_OPTS "-checks=*"
-      ",-cert-err58-cpp"
-      ",-cppcoreguidelines-pro-*"
-      ",-google-build-using-namespace"
-      ",-google-readability-casting"
-      ",-google-readability-todo"
-      ",-google-runtime-int"
-      ",-google-runtime-references"
-      ",-modernize-loop-convert"
-      ",-performance-inefficient-string-concatenation"
-      ",-readability-inconsistent-declaration-parameter-name"
-      ",-readability-named-parameter"
-      )
-    set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" ${TIDY_OPTS})
-    #set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-fix" "-checks=-*,google-readability-redundant-smartptr-get")
-  endif()
+find_program(CLANG_TIDY_EXE NAMES "clang-tidy-4.0" "clang-tidy40" "clang-tidy" DOC "Path to clang-tidy executable")
+if(NOT CLANG_TIDY_EXE)
+  message(STATUS "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy check skipped, need newer cmake")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+  string(CONCAT TIDY_OPTS "-checks=*"
+    ",-cert-err58-cpp"
+    ",-cppcoreguidelines-pro-*"
+    ",-google-build-using-namespace"
+    ",-google-readability-casting"
+    ",-google-readability-todo"
+    ",-google-runtime-int"
+    ",-google-runtime-references"
+    ",-modernize-loop-convert"
+    ",-performance-inefficient-string-concatenation"
+    ",-readability-inconsistent-declaration-parameter-name"
+    ",-readability-named-parameter"
+    )
+  set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" ${TIDY_OPTS})
+  #set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-fix" "-checks=-*,google-readability-redundant-smartptr-get")
 endif()
 
 if (USE_INTERNAL_TINYXML)

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,23 +1,12 @@
 #!/bin/bash -eu
 
 : ${INTEGRATION:=true}
-: ${CHECK:=false}
 
 if [[ "$INTEGRATION" == "true" ]]; then
   if uname -s | grep -q Linux; then
     sudo modprobe fuse
   elif uname -s | grep -q Darwin; then
     brew cask install osxfuse
+    brew reinstall openssl
   fi
 fi
-
-if [[ "$CHECK" == "true" ]]; then
-  if uname -s | grep -q Linux; then
-    wget https://cmake.org/files/v3.9/cmake-3.9.1-Linux-x86_64.tar.gz -O /tmp/cmake.tar.gz
-    tar -C /tmp/ -xf /tmp/cmake.tar.gz
-    mkdir /tmp/bin
-    ln -s $(ls -1 /tmp/cmake*/bin/cmake) /tmp/bin/
-  fi
-fi
-
-


### PR DESCRIPTION
Hi,

This PR updates build targets :
- it adds the newest available target, bionic ;
- it replaces the EOL trusty traget by the oldest supported one, xenial ;
- it runs clang-tidy from xenial, then removing the old cmake tricks ;
- minor MacOS / xcode version update.

Thank you 👍