### PR TITLE
Use std::min with proper cast

### DIFF
--- a/encfs/ConfigVar.cpp
+++ b/encfs/ConfigVar.cpp
@@ -27,10 +27,6 @@
 
 namespace encfs {
 
-#ifndef MIN
-inline int MIN(int a, int b) { return (a < b) ? a : b; }
-#endif
-
 ConfigVar::ConfigVar() : pd(new ConfigVarData) { pd->offset = 0; }
 
 ConfigVar::ConfigVar(const std::string &buf) : pd(new ConfigVarData) {
@@ -54,7 +50,7 @@ ConfigVar &ConfigVar::operator=(const ConfigVar &src) {
 void ConfigVar::resetOffset() { pd->offset = 0; }
 
 int ConfigVar::read(unsigned char *buffer_, int bytes) const {
-  int toCopy = MIN(bytes, pd->buffer.size() - pd->offset);
+  int toCopy = std::min<int>(bytes, pd->buffer.size() - pd->offset);
 
   if (toCopy > 0) {
     memcpy(buffer_, pd->buffer.data() + pd->offset, toCopy);

--- a/encfs/SSL_Cipher.cpp
+++ b/encfs/SSL_Cipher.cpp
@@ -48,10 +48,6 @@ const int MAX_KEYLENGTH = 32;  // in bytes (256 bit)
 const int MAX_IVLENGTH = 16;   // 128 bit (AES block size, Blowfish has 64)
 const int KEY_CHECKSUM_BYTES = 4;
 
-#ifndef MIN
-inline int MIN(int a, int b) { return (a < b) ? a : b; }
-#endif
-
 /**
     This produces the same result as OpenSSL's EVP_BytesToKey.  The difference
     is that here we can explicitly specify the key size, instead of relying on
@@ -94,14 +90,14 @@ int BytesToKey(int keyLen, int ivLen, const EVP_MD *md,
     }
 
     int offset = 0;
-    int toCopy = MIN(nkey, mds - offset);
+    int toCopy = std::min<int>(nkey, mds - offset);
     if (toCopy != 0) {
       memcpy(key, mdBuf + offset, toCopy);
       key += toCopy;
       nkey -= toCopy;
       offset += toCopy;
     }
-    toCopy = MIN(niv, mds - offset);
+    toCopy = std::min<int>(niv, mds - offset);
     if (toCopy != 0) {
       memcpy(iv, mdBuf + offset, toCopy);
       iv += toCopy;
@@ -760,7 +756,7 @@ static void flipBytes(unsigned char *buf, int size) {
 
   int bytesLeft = size;
   while (bytesLeft != 0) {
-    int toFlip = MIN(sizeof(revBuf), bytesLeft);
+    int toFlip = std::min<int>(sizeof(revBuf), bytesLeft);
 
     for (int i = 0; i < toFlip; ++i) {
       revBuf[i] = buf[toFlip - (i + 1)];

--- a/encfs/encfs.cpp
+++ b/encfs/encfs.cpp
@@ -54,10 +54,6 @@
 #include "FileUtils.h"
 #include "fuse.h"
 
-#ifndef MIN
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-#endif
-
 #define ESUCCESS 0
 
 using namespace std;


### PR DESCRIPTION
Hi,

This PR replaces inline `MIN` definition, with `std::min` template, and proper explicit casts.
In then closes #484.

Ben