### PR TITLE
Modify easylogging vendor, mute warn

### DIFF
--- a/vendor/github.com/muflihun/easyloggingpp/src/easylogging++.h
+++ b/vendor/github.com/muflihun/easyloggingpp/src/easylogging++.h
@@ -3632,6 +3632,7 @@ class SysLogInitializer {
  public:
   SysLogInitializer(const char* processIdent, int options = 0, int facility = 0) {
 #if defined(ELPP_SYSLOG)
+    (void)base::consts::kSysLogLoggerId;
     openlog(processIdent, options, facility);
 #else
     ELPP_UNUSED(processIdent);


### PR DESCRIPTION
Hi,

#596 muted a lot of easylogging++ compilation warnings, but there's the following one remaining, which pops-up several times :
```
/home/travis/build/vgough/encfs/vendor/github.com/muflihun/easyloggingpp/src/easylogging++.h:752:20: warning: ‘el::base::consts::kSysLogLoggerId’ defined but not used [-Wunused-variable]
440 static const char* kSysLogLoggerId                         =      "syslog";
```

Here's then a quick and simple fix.

Of course we'll have to revert it in case of future vendor update.
But will be rather simple.

Worth it then.

Thx 👍 