### PR TITLE
Initialize dummy variable

### DIFF
--- a/vendor/github.com/google/googletest/googletest/src/gtest-death-test.cc
+++ b/vendor/github.com/google/googletest/googletest/src/gtest-death-test.cc
@@ -1296,7 +1296,7 @@ static void StackLowerThanAddress(const void* ptr, bool* result) {
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 GTEST_ATTRIBUTE_NO_SANITIZE_HWADDRESS_
 static bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
Building fails with a warning that maybe this var didn't get initialized.  So I'm setting it to 0.  Is that right, wrong, catastrophic?  I dunno, but the warning went away and the build succeeds.  Maybe it would be better to just add -Wno-error=maybe-uninitialized to line 91 of vendor/github.com/google/googletest/googletest/cmake/internal_utils.cmake or something (that's what I did in #648, so head there if you prefer that path), but that feels dirrrrrty.