### PR TITLE
Exclude

### DIFF
--- a/encfs/DirNode.h
+++ b/encfs/DirNode.h
@@ -49,10 +49,14 @@ struct RenameEl;
 class DirTraverse {
  public:
   DirTraverse(std::shared_ptr<DIR> dirPtr, uint64_t iv,
-              std::shared_ptr<NameIO> naming, bool root);
+              std::shared_ptr<NameIO> naming, bool root,
+	      std::shared_ptr<EncFS_Opts>);
   ~DirTraverse();
 
   DirTraverse &operator=(const DirTraverse &src);
+
+  // pass options through so we can, e.g., get at opts->excludeArgv
+  std::shared_ptr<EncFS_Opts> opts;
 
   // returns FALSE to indicate an invalid DirTraverse (such as when
   // an invalid directory is requested for traversal)

--- a/encfs/FileUtils.h
+++ b/encfs/FileUtils.h
@@ -64,6 +64,12 @@ using RootPtr = std::shared_ptr<EncFS_Root>;
 
 enum ConfigMode { Config_Prompt, Config_Standard, Config_Paranoia };
 
+// Maximum number of exclude strings we'll process.  If the user
+// passes more, we complain and ignore the extra ones.
+#if !defined(MaxExcludeArgs)
+#define MaxExcludeArgs 64
+#endif
+
 /**
  * EncFS_Opts stores internal settings
  *
@@ -102,6 +108,9 @@ struct EncFS_Opts {
 
   bool requireMac;  // Throw an error if MAC is disabled
 
+  const char *excludeArgv[MaxExcludeArgs]; // exclude patterns
+  int excludeArgc; // number of exclude patterns
+
   ConfigMode configMode;
   std::string config;  // path to configuration file (or empty)
 
@@ -122,6 +131,7 @@ struct EncFS_Opts {
     readOnly = false;
     insecure = false;
     requireMac = false;
+    excludeArgc = 0;
   }
 };
 

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -156,6 +156,8 @@ static void usage(const char *name) {
             "verbose: output encfs debug messages\n"
             "  -i, --idle=MINUTES\t"
             "Auto unmount after period of inactivity\n"
+	    "  --exclude\t\t"
+	    "Exclude glob during reverse (may be specified multiple times)\n"
             "  --anykey\t\t"
             "Do not verify correct key is being used\n"
             "  --forcedecode\t\t"

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -346,7 +346,19 @@ static bool processArgs(int argc, char *argv[],
         PUSHARG("-d");
         break;
       case 'e':
-	cerr << "Saw exclude on the command line\n\n";
+	/* optarg contains a c-style string. Let's save it to an array
+	   of c-style strings in excludeArgv, and count them in
+	   excludeArgc */
+	if (out->opts->excludeArgc < MaxExcludeArgs) {
+	    out->opts->excludeArgv[out->opts->excludeArgc++] = optarg;
+	    if (out->isVerbose) {
+	      cout << autosprintf(_("Excluding '%s'"), optarg) << "\n";
+	    }
+	  } else {
+	    if (out->isVerbose) {
+	      cout << autosprintf(_("Too many excludes. Omitting '%s'"), optarg) << "\n";
+	    }
+	}
 	break;
       case 'i':
         out->idleTimeout = strtol(optarg, (char **)nullptr, 10);
@@ -468,6 +480,11 @@ static bool processArgs(int argc, char *argv[],
 
   if (!out->isThreaded) {
     PUSHARG("-s");
+  }
+
+  if (out->opts->excludeArgc != 0 && out->opts->reverseEncryption == false) {
+    cerr << "Must specify --reverse if patterns are specified with --exclude\n";
+    return false;
   }
 
   // for --unmount, we should have exactly 1 argument - the mount point

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -323,7 +323,7 @@ static bool processArgs(int argc, char *argv[],
         out->opts->insecure = true;
         break;
       case 'c':
-        /* Take config file path from command 
+        /* Take config file path from command
          * line instead of ENV variable */
         out->opts->config.assign(optarg);
         break;

--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -256,6 +256,7 @@ static bool processArgs(int argc, char *argv[],
       {"delaymount", 0, nullptr, 'M'},        // delay initial mount until use
       {"public", 0, nullptr, 'P'},            // public mode
       {"extpass", 1, nullptr, 'p'},           // external password program
+      {"exclude", 1, nullptr, 'e'},           // exclude from reverse
       // {"single-thread", 0, 0, 's'},  // single-threaded mode
       {"stdinpass", 0, nullptr, 'S'},  // read password from stdin
       {"syslogtag", 1, nullptr, 't'},  // syslog tag
@@ -290,8 +291,9 @@ static bool processArgs(int argc, char *argv[],
     // 't' : syslog tag
     // 'c' : configuration file
     // 'u' : unmount
+    // 'e' : exclude
     int res =
-        getopt_long(argc, argv, "HsSfvdmi:o:t:c:u", long_options, &option_index);
+        getopt_long(argc, argv, "HsSfvdmi:e:o:t:c:u", long_options, &option_index);
 
     if (res == -1) {
       break;
@@ -343,6 +345,9 @@ static bool processArgs(int argc, char *argv[],
       case 'd':
         PUSHARG("-d");
         break;
+      case 'e':
+	cerr << "Saw exclude on the command line\n\n";
+	break;
       case 'i':
         out->idleTimeout = strtol(optarg, (char **)nullptr, 10);
         out->opts->idleTracking = true;

--- a/vendor/github.com/google/googletest/googletest/src/gtest-death-test.cc
+++ b/vendor/github.com/google/googletest/googletest/src/gtest-death-test.cc
@@ -1296,7 +1296,7 @@ static void StackLowerThanAddress(const void* ptr, bool* result) {
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 GTEST_ATTRIBUTE_NO_SANITIZE_HWADDRESS_
 static bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
Issue #55 is a feature-request for a --exclude option.  This patch implements that option, though it's not ready for merge yet.

First, do people still want this feature?  I know I do, but I don't know if anybody else using encfs still does.

Second, I haven't written tests yet.  Left to my own devices, I'd do integration tests in python.  There's not much point wrestling with C++ for that kind of high-level "make a dir, run encfs, see if the files are excluded" tests.  I could dig into gtest and do C++ tests, but that's extra work, and I don't want to do it if this patch has no chance of landing in the repo.

So, I guess, my question here is tol @vgough or @benrubson:  do you want to take the time to look at the patch and tell me what you would want to see before merging?  I can get this code to the point where *I* can use it, but my guess is that code review might tell me to do things differently.  For example, maybe the pattern matching is better placed somewhere else.  

I've been using encfs for a looong time.  It's great, and I'm happy to help make it better if the project is interested in contributions.  If it's not, I'll just carry this in my repo instead.

Thanks much!