### PR TITLE
Bug when mountpoint is not empty with -i option

### DIFF
--- a/encfs/main.cpp
+++ b/encfs/main.cpp
@@ -818,7 +818,10 @@ int main(int argc, char *argv[]) {
       RLOG(ERROR) << "Internal error: Caught unexpected exception";
     }
 
-    if (ctx->args->idleTimeout > 0) {
+    // We need to check if returnCode is equal to EXIT_SUCCESS
+    // when directory is mounted, because if we do not check and
+    // user added -i option, it will exit with coredump SIGSEGV.
+    if (ctx->args->idleTimeout > 0 && returnCode == EXIT_SUCCESS) {
       ctx->running = false;
       // wake up the thread if it is waiting..
       VLOG(1) << "waking up monitoring thread";


### PR DESCRIPTION
When user attempts to mount in a mountpoint that is not empty and added -i option, encfs exits with coredump SIGSEGV.

With -i option, encfs needs also to check that fuse_main returned 0.