### PR TITLE
Allow build with cmake 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 
 # 3.0.2 preferred, but we can often get by with 2.8.
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...3.10)
 if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION} LESS 3.0.2)
   message(WARNING "You should use cmake 3.0.2 or newer for configuration to run correctly.")
 endif()


### PR DESCRIPTION
use min...max syntax to allow build with newer cmake.

ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html